### PR TITLE
feat(smartpicker): API extension to support plain text insertion in word documents

### DIFF
--- a/cell/api.js
+++ b/cell/api.js
@@ -463,6 +463,11 @@ var editor;
     return AscCommon.g_clipboardBase.Button_Copy();
   };
 
+  spreadsheet_api.prototype.PastePlainText = function(text) {
+
+	this.wb.pasteData(AscCommon.c_oAscClipboardDataFormat.Text, text, null, null, true);
+  };
+
   spreadsheet_api.prototype.asc_Paste = function() {
     if (!AscCommon.g_clipboardBase.IsWorking()) {
       return AscCommon.g_clipboardBase.Button_Paste();
@@ -9640,6 +9645,7 @@ var editor;
   prot["asc_Resize"] = prot.asc_Resize;
   prot["asc_Copy"] = prot.asc_Copy;
   prot["asc_Paste"] = prot.asc_Paste;
+  prot["PastePlainText"] = prot.PastePlainText;
   prot["asc_SpecialPaste"] = prot.asc_SpecialPaste;
   prot["asc_Cut"] = prot.asc_Cut;
   prot["asc_Undo"] = prot.asc_Undo;

--- a/slide/api.js
+++ b/slide/api.js
@@ -1840,6 +1840,11 @@ background-repeat: no-repeat;\
 		return AscCommon.g_clipboardBase.Button_Paste();
 	};
 
+	asc_docs_api.prototype.PastePlainText = function(text)
+	{
+		AscCommon.Editor_Paste_Exec(this, AscCommon.c_oAscClipboardDataFormat.Text, text, undefined, undefined, undefined, undefined, undefined);
+	};
+
 	asc_docs_api.prototype.asc_ShowSpecialPasteButton = function(props)
 	{
 		if (window["NATIVE_EDITOR_ENJINE"])
@@ -9458,6 +9463,7 @@ background-repeat: no-repeat;\
 	asc_docs_api.prototype['Update_ParaTab']                      = asc_docs_api.prototype.Update_ParaTab;
 	asc_docs_api.prototype['Cut']                                 = asc_docs_api.prototype.Cut;
 	asc_docs_api.prototype['Paste']                               = asc_docs_api.prototype.Paste;
+	asc_docs_api.prototype['PastePlainText']                      = asc_docs_api.prototype.PastePlainText;
 	asc_docs_api.prototype['Share']                               = asc_docs_api.prototype.Share;
 	asc_docs_api.prototype['asc_Save']                            = asc_docs_api.prototype.asc_Save;
 	asc_docs_api.prototype['forceSave']                           = asc_docs_api.prototype.forceSave;

--- a/word/api.js
+++ b/word/api.js
@@ -2282,6 +2282,11 @@ background-repeat: no-repeat;\
 		return AscCommon.g_clipboardBase.Button_Paste();
 	};
 
+	asc_docs_api.prototype.PastePlainText = function(text)
+	{
+		AscCommon.Editor_Paste_Exec(this, AscCommon.c_oAscClipboardDataFormat.Text, text, undefined, undefined, undefined, undefined, undefined);
+	};
+
 	asc_docs_api.prototype.Share = function()
 	{
 
@@ -14817,6 +14822,7 @@ background-repeat: no-repeat;\
 	asc_docs_api.prototype['Update_ParaTab']                            = asc_docs_api.prototype.Update_ParaTab;
 	asc_docs_api.prototype['Cut']                                       = asc_docs_api.prototype.Cut;
 	asc_docs_api.prototype['Paste']                                     = asc_docs_api.prototype.Paste;
+	asc_docs_api.prototype['PastePlainText']                            = asc_docs_api.prototype.PastePlainText;
 	asc_docs_api.prototype['Share']                                     = asc_docs_api.prototype.Share;
 	asc_docs_api.prototype['asc_Save']                                  = asc_docs_api.prototype.asc_Save;
 	asc_docs_api.prototype['forceSave']                                 = asc_docs_api.prototype.forceSave;


### PR DESCRIPTION
This PR adds API support for plain text insertions for the smart picker feature.

Todo:

- [x] extend to other editors, not only word