### PR TITLE
fix(license): remove stale proprietary code markers

### DIFF
--- a/cell/model/Serialize.js
+++ b/cell/model/Serialize.js
@@ -12519,7 +12519,6 @@
                     return oThis.ReadPic(t,l, oDrawing);
                 });
             }
-            /** proprietary begin **/
             else if ( c_oSer_DrawingType.GraphicFrame == type )
             {
                 //todo удалить
@@ -12527,7 +12526,6 @@
                     return oThis.ReadGraphicFrame(t, l, oDrawing);
                 });
             }
-            /** proprietary end **/
             else if ( c_oSer_DrawingType.pptxDrawing == type )
             {
                 oDrawing.graphicObject = this.ReadPptxDrawing();


### PR DESCRIPTION
## Summary

Remove stale proprietary begin/end comment markers from sdkjs/cell/model/Serialize.js. The code between the markers is standard AGPL-licensed code — the markers were leftover upstream artifacts.