### PR TITLE
Translate Russian comments to English in sdkjs/common (proof of concept)

### DIFF
--- a/common/api/addTextSettings.js
+++ b/common/api/addTextSettings.js
@@ -33,7 +33,7 @@
 	function CAddTextSettings()
 	{
 		this.TextPr        = null;
-		this.CursorOutside = false; // Работает совместно с TextPr
+		this.CursorOutside = false; // Works together with TextPr
 		this.WrapSpaces    = false;
 	}
 	CAddTextSettings.prototype.SetTextPr = function(oTextPr)

--- a/common/api/restrictionSettings.js
+++ b/common/api/restrictionSettings.js
@@ -28,7 +28,7 @@
 (function (window)
 {
 	/**
-	 * Дополнительные настройки при выставлении asc_setRestriction в редакторах
+	 * Additional settings when applying asc_setRestriction in editors
 	 * @constructor
 	 */
 	function CRestrictionSettings()

--- a/common/applyDocumentChanges.js
+++ b/common/applyDocumentChanges.js
@@ -23,10 +23,10 @@
  *
  */
 
-window['AscApplyChanges'] = true;	// Флаг для проверки
+window['AscApplyChanges'] = true;	// Flag for checking
 window['AscChanges'] = [
 
-];			// Массив строк изменений - изменения всех пользователей [[changes_1],[changes_2],..,[changes_n]]
+];			// Array of change strings - changes from all users [[changes_1],[changes_2],..,[changes_n]]
 
-// Только для не минимизированной версии. В сборку этот файл не включать!!!
-window['AscNotLoadAllScript'] = true;	// Флаг для проверки
+// Only for non-minified version. Do not include this file in the build!!!
+window['AscNotLoadAllScript'] = true;	// Flag for checking

--- a/common/device_scale.js
+++ b/common/device_scale.js
@@ -72,7 +72,7 @@
 		{
 			if (true)
 			{
-				// это "подстройка под интерфейс" - после убирания этого в общий код - удалить
+				// this is an "interface adjustment" - remove this after it is moved into the shared code
 				if (Math.abs(supportedScaleValues[i] - systemScaling) > 0.0001)
 				{
 					if (supportedScaleValues[i] > (systemScaling - 0.0001))

--- a/common/downloaderfiles.js
+++ b/common/downloaderfiles.js
@@ -39,7 +39,7 @@ function FileHandler() {
             window.focus();
         }
         else {
-			//делаем как docs.google.com, решение с form submit в схеме с socket вызывало ошибку 405 (Method Not Allowed)
+			//done like docs.google.com, the form submit solution caused a 405 error (Method Not Allowed) with the socket scheme
             var frmWindow = getIFrameWindow( file );
 //            frmWindow.focus();
         }


### PR DESCRIPTION
## Summary

This is a proof-of-concept for translating ~22,500 lines of Russian comments across the sdkjs codebase into English. This PR covers 5 small files in `sdkjs/common/` to establish the translation pattern and quality standard.

## Files translated

| File | Lines | Russian comments translated |
|------|-------|---------------------------|
| `common/applyDocumentChanges.js` | 32 | 4 comments |
| `common/downloaderfiles.js` | 77 | 1 comment |
| `common/api/restrictionSettings.js` | 66 | 1 JSDoc description |
| `common/api/addTextSettings.js` | 70 | 1 comment |
| `common/device_scale.js` | 112 | 1 comment |

**Total: 5 files, ~357 lines, 8 comments translated**

## Translation approach

- Technical terms kept in English (variable names, API references)
- Preserved comment formatting (indentation, style)
- Preserved original tone (terse/technical where applicable)
- TODO/FIXME prefixes preserved where applicable
- No code changes — comments only

## Next steps

After this POC is approved, subsequent PRs will batch-translate files in groups of 5-10 following this pattern. The planned roadmap:
1. `sdkjs/common/` (remaining files)
2. `sdkjs/word/`
3. `sdkjs/cell/`
4. `sdkjs/slide/`
5. `sdkjs/pdf/`
6. `core/` (C++)