### PR TITLE
fix: :bug: Ensure that device_scale.js is included in the build

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -540,5 +540,22 @@ module.exports = function(grunt) {
 		defaultTasks.push('copy-maps');
 	}
 	grunt.registerTask('default', defaultTasks);
-	grunt.registerTask('develop', ['clean-develop', 'build-develop']);
+	// this file, device_scale is used in html templates and needs to be copied
+	// it is basically it's own thing, but processed like this to be consistent and not hacky
+	grunt.registerTask('copy-standalone', 'Copy standalone scripts needed by HTML templates', function () {
+		grunt.initConfig({
+			copy: {
+				standalone: {
+					files: [{
+						expand: true,
+						cwd: '../common/',
+						src: ['device_scale.js'],
+						dest: path.join(deploy, 'common')
+					}]
+				}
+			}
+		});
+		grunt.task.run('copy');
+	});
+	grunt.registerTask('develop', ['clean-develop', 'build-develop', 'copy-standalone']);
 };

--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -208,6 +208,7 @@ module.exports = function(grunt) {
 		{
 			cwd: '../common/',
 			src: [
+				'device_scale.js',
 				'Drawings/Format/path-boolean-min.js',
 				'Charts/ChartStyles.js',
 				'SmartArts/SmartArtData/*',


### PR DESCRIPTION
https://github.com/Euro-Office/DocumentServer/issues/56

device-scale.js is added into html templates in web-apps and also into the build process. It falls through the cracks in the dev mode. Therefore we ensure it is placed into common files to be copied.