### PR TITLE
fix(ios): keyboard persistence in word editor mobile

### DIFF
--- a/common/Scrolls/mobileTouchManagerBase.js
+++ b/common/Scrolls/mobileTouchManagerBase.js
@@ -1361,6 +1361,17 @@
 		this.ContextMenuShowTimerId = setTimeout(function()
 		{
 			that.ContextMenuShowTimerId = -1;
+
+			// On iOS the keyboard and the bottom formatting sheet occupy the same space.
+			// If the keyboard is visible (visualViewport has shrunk) suppress the sheet —
+			// showing it would steal keyboard focus and dismiss the keyboard.
+			// The user can dismiss the keyboard first and then tap to get the sheet.
+			if (AscCommon.AscBrowser.isSafariMobile && window.visualViewport &&
+				window.visualViewport.height < window.innerHeight * 0.8)
+			{
+				return;
+			}
+
 			var _pos = that.delegate.GetContextMenuPosition();
 			if (AscCommon.g_inputContext) AscCommon.g_inputContext.isGlobalDisableFocus = true;
 			that.Api.sendEvent("asc_onShowPopMenu", _pos.X, _pos.Y, _pos.Mode);

--- a/common/browser.js
+++ b/common/browser.js
@@ -177,6 +177,11 @@ AscBrowser.isAndroidNativeApp = (AscBrowser.userAgent.indexOf("ascandroidwebview
 
 AscBrowser.isTelegramWebView = (typeof TelegramWebviewProxy === "object") ? true : false;
 
+// True for Mobile Safari AND for iOS WKWebView apps that omit "Safari" from their
+// custom user agent (e.g. Nextcloud iOS). Both environments are WebKit on iOS and
+// require the same hidden-input positioning workaround.
+AscBrowser.isSafariMobile = (AscBrowser.isSafari || AscBrowser.isAppleDevices) && AscBrowser.isMobile;
+
 AscBrowser.zoom = 1;
 
 AscBrowser.isCustomScaling = function()

--- a/common/text_input.js
+++ b/common/text_input.js
@@ -403,7 +403,7 @@
 			var xPos    = x ? x : parseInt(oTarget.style.left);
 			var yPos    = (y ? y : parseInt(oTarget.style.top)) + parseInt(oTarget.style.height);
 
-            if (AscCommon.AscBrowser.isSafari && AscCommon.AscBrowser.isMobile)
+            if (AscCommon.AscBrowser.isSafariMobile)
                 xPos = -100;
 
 			if (!this.isDebug && !this.isSystem)
@@ -573,7 +573,7 @@
 				this.debugTexBoxMaxH = 50;
 			}
 
-			if (AscCommon.AscBrowser.isSafari && AscCommon.AscBrowser.isMobile)
+			if (AscCommon.AscBrowser.isSafariMobile)
 			    _left = -100;
 
 			this.HtmlDiv.style.left = _left + "px";

--- a/common/text_input2.js
+++ b/common/text_input2.js
@@ -71,7 +71,16 @@
 		this.TargetId = null; // id caret
 		this.HtmlDiv  = null; // для незаметной реализации одной textarea недостаточно. parent для HtmlArea
 		this.HtmlArea = null; // HtmlArea - элемент для ввода
-		this.ElementType = InputTextElementType.TextArea;
+		// On iOS (word editor only), a full-canvas contenteditable is required so that
+		// every tap lands on a text input element — iOS only keeps keyboard when the tap
+		// target IS a text input. opacity:0 excludes elements from iOS hit-testing; we
+		// use color:transparent so the element is UIKit-visible but invisible to the user.
+		// Gated to Word: cell/slide use different canvas z-index layouts and forwarding
+		// targets that have not been validated.
+		this.ElementType = AscCommon.AscBrowser.isSafariMobile &&
+		                   this.Api.editorId === AscCommon.c_oEditorId.Word
+			? InputTextElementType.ContentEditableDiv
+			: InputTextElementType.TextArea;
 
 		// ---------------------------------------------------------------
 		// chrome element for left/top
@@ -880,10 +889,34 @@
 	};
 	CTextInputPrototype.setReadOnlyWrapper = function(val)
 	{
-		this.HtmlArea.readOnly = this.isDisableKeyboard ? true : val;
+		if (this.ElementType === InputTextElementType.TextArea)
+		{
+			this.HtmlArea.readOnly = this.isDisableKeyboard ? true : val;
+		}
+		else
+		{
+			var _disabled = this.isDisableKeyboard || val;
+			this.HtmlArea.contentEditable = _disabled ? 'false' : 'true';
+			var _scrollable = document.getElementById('area_id_main');
+			if (_scrollable)
+				_scrollable.style.pointerEvents = _disabled ? 'none' : 'auto';
+			if (_disabled && document.activeElement === this.HtmlArea)
+				this.HtmlArea.blur();
+		}
 	};
 	CTextInputPrototype.setInterfaceEnableKeyEvents = function(value)
 	{
+		// On iOS with ContentEditableDiv: ignore false calls while the overlay has focus.
+		// These come from Framework7 sheet/popover open events and must not disrupt the
+		// active keyboard session. The real exit-edit-mode path goes through
+		// setReadOnlyWrapper(true) which explicitly calls blur().
+		if (!value && AscCommon.AscBrowser.isSafariMobile &&
+			this.ElementType === InputTextElementType.ContentEditableDiv &&
+			document.activeElement === this.HtmlArea)
+		{
+			return;
+		}
+
 		this.InterfaceEnableKeyEvents = value;
 		if (true === this.InterfaceEnableKeyEvents)
 		{
@@ -956,21 +989,38 @@
 		var _style = "";
 		if (!TEXT_INPUT_DEBUG)
 		{
-			_style = ("left:-" + (this.HtmlAreaWidth >> 1) + "px;top:" + (-this.HtmlAreaOffset) + "px;");
-			_style += "color:transparent;caret-color:transparent;background:transparent;";
-
-			if (this.Api.isUseOldMobileVersion())
-				_style += (AscCommon.AscBrowser.isAppleDevices && !AscCommon.AscBrowser.isTelegramWebView && (AscCommon.AscBrowser.maxTouchPoints > 0)) ? "font-size:0px;" : "font-size:8px;";
+			if (this.ElementType === InputTextElementType.ContentEditableDiv && AscCommon.AscBrowser.isSafariMobile)
+			{
+				// Full-canvas coverage. MUST use color:transparent not opacity:0 —
+				// iOS excludes opacity:0 elements from hit-testing so keyboard is dismissed.
+				// With color:transparent the element is UIKit-visible at the tap location.
+				_style = "left:0;top:0;width:100%;height:100%;color:transparent;caret-color:transparent;background:transparent;outline:none;";
+			}
 			else
-				_style += "font-size:8px;";
+			{
+				_style = ("left:-" + (this.HtmlAreaWidth >> 1) + "px;top:" + (-this.HtmlAreaOffset) + "px;");
+				_style += "color:transparent;caret-color:transparent;background:transparent;";
+
+				if (this.Api.isUseOldMobileVersion())
+					_style += (AscCommon.AscBrowser.isAppleDevices && !AscCommon.AscBrowser.isTelegramWebView && (AscCommon.AscBrowser.maxTouchPoints > 0)) ? "font-size:0px;" : "font-size:8px;";
+				else
+					_style += "font-size:8px;";
+			}
 		}
 		else
 		{
 			_style = "left:0px;top:0px;color:black;caret-color:black;font-size:16px;background:transparent;";
 		}
-		_style += ("border:none;position:absolute;text-shadow:0 0 0 #000;outline:none;width:" + this.HtmlAreaWidth + "px;height:50px;");
-		_style += "overflow:hidden;padding:0px;margin:0px;font-family:arial;resize:none;font-weight:normal;box-sizing:content-box;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;";
-		_style += "touch-action: none;-webkit-touch-callout: none;";
+		if (this.ElementType === InputTextElementType.ContentEditableDiv && AscCommon.AscBrowser.isSafariMobile)
+		{
+			_style += "border:none;position:absolute;padding:0px;margin:0px;";
+		}
+		else
+		{
+			_style += ("border:none;position:absolute;text-shadow:0 0 0 #000;outline:none;width:" + this.HtmlAreaWidth + "px;height:50px;");
+			_style += "overflow:hidden;padding:0px;margin:0px;font-family:arial;resize:none;font-weight:normal;box-sizing:content-box;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;";
+			_style += "touch-action: none;-webkit-touch-callout: none;";
+		}
 
 		this.HtmlArea.setAttribute("style", _style);
 		this.HtmlArea.setAttribute("spellcheck", false);
@@ -1058,7 +1108,59 @@
 		oHtmlDivScrollable.style.height = parentStyle.height;
 		oHtmlDivScrollable.style.overflow = "hidden";
 		oHtmlDivScrollable.appendChild(this.HtmlDiv);
-		oHtmlParent.parentNode.appendChild(oHtmlDivScrollable);
+		// On iOS ContentEditableDiv: append inside oHtmlParent (e.g. id_main_view) so our
+		// overlay is a direct sibling of id_viewer_overlay (z-index:2) and id_target_cursor
+		// (z-index:4). Touch events are forwarded as PointerEvents to id_viewer_overlay where
+		// the mobile touch manager's cursor-placement handlers are registered.
+		if (this.ElementType === InputTextElementType.ContentEditableDiv && AscCommon.AscBrowser.isSafariMobile)
+			oHtmlParent.appendChild(oHtmlDivScrollable);
+		else
+			oHtmlParent.parentNode.appendChild(oHtmlDivScrollable);
+
+		if (this.ElementType === InputTextElementType.ContentEditableDiv && AscCommon.AscBrowser.isSafariMobile)
+		{
+			// Container and div cover canvas fully. z-index:3 exceeds canvas overlay (z-index:2).
+			// pointer-events stays none until showKeyboard() activates the overlay.
+			oHtmlDivScrollable.style.zIndex = '3';
+			this.HtmlDiv.style.left   = '0px';
+			this.HtmlDiv.style.top    = '0px';
+			this.HtmlDiv.style.width  = '100%';
+			this.HtmlDiv.style.height = '100%';
+
+			// Forward touch events to id_viewer_overlay — the mobile touch manager's
+			// mainOnTouchStart/End handlers are registered there, not on area_id.
+			// Lazy lookup: id_viewer_overlay may not exist at init time.
+			var _fwdTarget = null;
+			var _getFwdTarget = function()
+			{
+				if (!_fwdTarget)
+					_fwdTarget = document.getElementById('id_viewer_overlay');
+				return _fwdTarget;
+			};
+			// The touch manager registers pointerdown/move/up on id_viewer_overlay.
+			// Dispatch PointerEvent so those handlers fire for cursor placement.
+			var _fwdPointer = function(e, type)
+			{
+				var _target = _getFwdTarget();
+				if (!_target) return;
+				var _t = (e.changedTouches || e.touches)[0];
+				if (!_t) return;
+				try {
+					_target.dispatchEvent(new PointerEvent(type, {
+						bubbles: true, cancelable: true,
+						clientX: _t.clientX, clientY: _t.clientY,
+						pageX: _t.pageX, pageY: _t.pageY,
+						screenX: _t.screenX, screenY: _t.screenY,
+						pointerId: 1, pointerType: 'touch', isPrimary: true,
+						pressure: type === 'pointerup' ? 0 : 0.5
+					}));
+				} catch(_e) {}
+			};
+			this.HtmlArea.addEventListener('touchstart',  function(e) { _fwdPointer(e, 'pointerdown'); }, {passive: true});
+			this.HtmlArea.addEventListener('touchmove',   function(e) { _fwdPointer(e, 'pointermove'); }, {passive: true});
+			this.HtmlArea.addEventListener('touchend',    function(e) { _fwdPointer(e, 'pointerup');   }, {passive: true});
+			this.HtmlArea.addEventListener('touchcancel', function(e) { _fwdPointer(e, 'pointercancel'); }, {passive: true});
+		}
 	};
 	CTextInputPrototype.onResize = function(editorContainerId)
 	{
@@ -1174,7 +1276,11 @@
 		var yPos = (y ? y : parseInt(oTarget.style.top)) + parseInt(oTarget.style.height);
 
 		if (AscCommon.AscBrowser.isSafariMobile)
+		{
+			if (this.ElementType === InputTextElementType.ContentEditableDiv)
+				return; // full-canvas overlay — no repositioning needed
 			xPos = -100;
+		}
 
 		if (this.Api.editorId === AscCommon.c_oEditorId.Presentation)
 		{
@@ -1246,10 +1352,14 @@
 	{
 		if (this.virtualKeyboardReadOnly_ShowKeyboard)
 		{
-			if (this.HtmlArea.readOnly === true)
-			{
+			if (this.ElementType === InputTextElementType.TextArea && this.HtmlArea.readOnly === true)
 				this.setReadOnlyWrapper(false);
-			}
+		}
+
+		if (AscCommon.AscBrowser.isSafariMobile && this.ElementType === InputTextElementType.ContentEditableDiv)
+		{
+			this.setReadOnlyWrapper(false);
+			return;
 		}
 
 		if (!this.Api.asc_IsFocus())

--- a/common/text_input2.js
+++ b/common/text_input2.js
@@ -1173,7 +1173,7 @@
 		var xPos = x ? x : parseInt(oTarget.style.left);
 		var yPos = (y ? y : parseInt(oTarget.style.top)) + parseInt(oTarget.style.height);
 
-		if (AscCommon.AscBrowser.isSafari && AscCommon.AscBrowser.isMobile)
+		if (AscCommon.AscBrowser.isSafariMobile)
 			xPos = -100;
 
 		if (this.Api.editorId === AscCommon.c_oEditorId.Presentation)


### PR DESCRIPTION
## Summary

iOS Safari dismisses the keyboard on every canvas tap because the hidden textarea sits offscreen at `left:-100px` — iOS only keeps keyboard when the tap lands on a text input. This replaces the textarea with a transparent `contenteditable` div covering the canvas, so every tap lands on a text input element and keyboard persists.

Also suppresses the 500ms formatting sheet timer when the keyboard is already up (it would steal focus and dismiss keyboard).

## Changes

- `common/browser.js` — add `isSafariMobile` to cover iOS WKWebView apps with custom UAs
- `common/text_input.js` / `text_input2.js` — use `isSafariMobile` for textarea positioning; switch to ContentEditableDiv for iOS word editor
- `common/Scrolls/mobileTouchManagerBase.js` — suppress formatting sheet when keyboard is visible

⚠️ Gated to word editor only (`editorId === Word`). Cell/slide not yet validated.


**Related:** Euro-Office/web-apps#74 — web-apps keyboard overlay exit, build chunk & FAB visibility

---

<details>
<summary>Painful level of detail</summary>

# iOS Keyboard Investigation — EuroOffice Mobile Editor

## Status: RESOLVED (2026-06-02)

Keyboard shows, stays up, cursor moves on tap, hides when exiting edit mode — verified in Mobile Safari, desktop Chrome mobile emulation, and Nextcloud iOS app via the same-origin proxy.


---

## ⚠️ Testing Gotchas

### iOS Simulator — software keyboard may be off
If the keyboard shows only a **thin bar / tick mark (~20px)** and immediately dismisses, check whether the Simulator software keyboard is enabled:
- `Hardware → Keyboard → Toggle Software Keyboard` (or `⌘K`)
- When the software keyboard is off, iOS shows only the accessory bar. This looks identical to a "keyboard dismissed by UIKit" bug. Several observations during this investigation may have been Simulator keyboard-off behaviour, not real iOS dismissals.
- Always verify on a **physical iPhone** before concluding a keyboard bug is real.

### Typing slowness — re-test after keyboard fix
Earlier sessions noted "typing slowness" and attributed it to WebSocket round-trips. This should be re-tested: the keyboard was broken during those sessions (repeated dismiss/re-show cycles would cause erratic input processing). With the fix in place the slowness may be gone.


---

## Problem

On iOS (Mobile Safari, WKWebView), tapping in the document canvas in edit mode caused the keyboard to briefly flash then dismiss.

## Environment

- EuroOffice DocumentServer proxied through Nextcloud at `http://192.168.178.126:8081/ds/`
- Nextcloud at `http://192.168.178.126:8081`
- Same-origin proxy required (see Local Dev Proxy section)
- Physical iPhone + iOS Simulator


---

## Root Cause (confirmed)

iOS evaluates the gesture at touchend (~300ms). If the tap started on a **canvas** (not a text input), iOS decides "not a text input tap" → native UIKit keyboard dismissal (empty JS stack trace on blur).

The fix: place a transparent `contenteditable` div **covering the entire canvas area** so every user tap lands on a text input element. iOS then treats it as a text-input tap and keeps the keyboard.

**Critical detail:** `opacity:0` causes iOS to exclude elements from hit-testing entirely — iOS still dismisses keyboard even for a tap on an `opacity:0` contenteditable. Must use `color:transparent; caret-color:transparent; background:transparent` (opacity:1) instead.


---

## Solution — sdkjs changes (`fix/ios-wkwebview-keyboard` branch)

### `common/browser.js` (commit 745db40)
Added `AscBrowser.isSafariMobile = (isSafari || isAppleDevices) && isMobile` to cover iOS WKWebView apps (Nextcloud iOS) that omit "safari" from their UA.

### `common/text_input2.js`

**ElementType switch:** For `isSafariMobile`, use `ContentEditableDiv` instead of `TextArea`:
```javascript
this.ElementType = AscCommon.AscBrowser.isSafariMobile
    ? InputTextElementType.ContentEditableDiv
    : InputTextElementType.TextArea;
```

**CSS:** Must use `color:transparent` NOT `opacity:0`:
```javascript
_style = "left:0;top:0;width:100%;height:100%;color:transparent;caret-color:transparent;background:transparent;outline:none;";
```

**DOM placement:** Append inside `oHtmlParent` (= `id_main_view`) NOT `oHtmlParent.parentNode`. This makes the overlay a direct sibling of `id_viewer_overlay` at the correct z-index level.

**Touch forwarding:** Dispatch `PointerEvent` (NOT `TouchEvent`) to `id_viewer_overlay`. The mobile touch manager registers `pointerdown`/`pointermove`/`pointerup` handlers there (because `isUsePointerEvents = true` for modern iOS Safari).

**showKeyboard():** For iOS ContentEditableDiv, enable overlay via `setReadOnlyWrapper(false)` and return without calling `focusHtmlElement()` — programmatic focus is dismissed by UIKit outside a direct user gesture.

**setInterfaceEnableKeyEvents guard:** Ignore `false` calls while contenteditable has focus — these come from Framework7 sheet/popover events, not real exit-edit-mode.

**setReadOnlyWrapper:** For ContentEditableDiv, call `HtmlArea.blur()` when disabling so iOS hides keyboard on edit mode exit.

**move():** Return early for ContentEditableDiv — full-canvas overlay doesn't need repositioning.

### `common/Scrolls/mobileTouchManagerBase.js`

Suppress the bottom formatting sheet when keyboard is visible — the sheet would steal focus and dismiss keyboard:
```javascript
if (AscCommon.AscBrowser.isSafariMobile && window.visualViewport &&
    window.visualViewport.height < window.innerHeight * 0.8)
{
    return;
}
```


---

## Key Architecture Discoveries

### DOM structure (word editor)
```
id_panel_top
  id_hor_ruler
  id_main_view                    ← oHtmlParent (InitBrowserInputContext target_id="id_target_cursor")
    id_viewer (canvas, z-index:1)
    id_viewer_overlay (canvas, z-index:2)  ← touch manager registers pointerdown here
    id_target_cursor (div, z-index:4)
    area_id_main (our overlay, z-index:10) ← appended here, set by HtmlPage.initEventsMobile
      area_id_parent (HtmlDiv)
        area_id (contenteditable, our keyboard input)
```

`HtmlPage.initEventsMobile()` (isUseOldMobileVersion=true path):
- Sets `area_id_main.style.zIndex = 10` (via `TextBoxBackground.HtmlElement.parentNode.parentNode`)
- Calls `MobileTouchManager.initEvents("area_id")` — registers iScroll on area_id

### Event routing
- `mainOnTouchStart` / `mainOnTouchEnd` are registered on `id_viewer_overlay` via `pointerdown`/`pointerup`
- `isUsePointerEvents = true` for Safari ≥ 15 → touch manager uses pointer events, not touch events
- Forwarding must dispatch `PointerEvent`, not `TouchEvent`
- Synthetic PointerEvent has `isTrusted=false` but no isTrusted check exists in the touch manager

### Why cross-origin iframe was a red herring
iOS Safari does restrict keyboard in cross-origin iframes, but that only prevented document loading. The keyboard issue exists on same-origin too because the fundamental problem is the canvas tap not being recognized as a text-input tap.


---

## Local Dev Proxy (same-origin setup)

iOS Safari blocks keyboard in cross-origin iframes. For local dev, proxy EuroOffice through Nextcloud:

**File:** `develop/setup/eo-proxy.conf` (Apache config, mounted into nextcloud container)

```apache
<Location /ds/>
    ProxyPass http://eo/ upgrade=websocket
    ProxyPassReverse http://eo/
    ProxyPreserveHost Off
    RequestHeader set X-Forwarded-Prefix "/ds"
</Location>
```

**occ settings:**
```bash
php occ config:app:set eurooffice DocumentServerUrl --value='http://192.168.178.126:8081/ds'
php occ config:app:set eurooffice DocumentServerInternalUrl --value='http://eo'
```

**Persistence:** Add to docker-compose.override.yml:
```yaml
services:
  nextcloud:
    volumes:
      - ./setup/eo-proxy.conf:/etc/apache2/conf-available/eo-proxy.conf:ro
```
Then in the container: `a2enmod proxy proxy_http proxy_wstunnel headers && a2enconf eo-proxy`

Note: `X-Forwarded-Prefix: /ds` is critical — without it, the DS constructs cache/Editor.bin URLs without the `/ds` prefix and they 404.


---

## Related Repos

### iOS app — `ios-builds/ios`
Context doc: `/Users/jamesmanuel/ios-builds/ios/.claude/eurooffice.md`

Relevant branches:
- `feature/eurooffice-fixes`: double-tap guard (`isNavigatingMetadata`), spinner-on-exit fix, `isScrollEnabled=true`, `isInspectable=true`
- Private API swizzle (`NCViewerDirectEditingKeyboard.swift`) — investigated but not needed with this fix

### web-apps — `DocumentServer/web-apps`
EuroOffice-specific additions in `apps/documenteditor/mobile/src/`:
- `page/main.jsx`: `showKeyboard()` called in `turnOffViewerMode()` for iOS
- `view/Toolbar.jsx`: `⌨` keyboard toggle button (`ctx.HtmlArea.focus()` in `onTouchEnd`) — this is what triggers keyboard on FAB tap since programmatic focus from `showKeyboard()` alone can't show keyboard

### sdkjs — `DocumentServer/sdkjs`
Branch: `fix/ios-wkwebview-keyboard`
2 commits ahead of main:
1. `745db40` — `isSafariMobile` detection
2. (staged/committed after this session) — ContentEditableDiv + proxy setup


---

## Approaches That Failed

1. **isSafariMobile detection only** — correct but insufficient (textarea still offscreen)
2. **isScrollEnabled=true** — no effect on keyboard
3. **tabIndex=-1 on `<a>` elements** — doesn't prevent iOS auto-focus
4. **MutationObserver to set tabindex** — broke styling, performance issues
5. **pointer-events:none on document** — worse
6. **focus intercept in document.focus handler** — iOS blurs at UIKit level before JS fires
7. **blur re-focus handler** — same
8. **opacity:0 contenteditable** — iOS excludes from hit-testing, keyboard dismissed
9. **Touch forwarding to word_mobile_element** — element doesn't exist in this editor path
10. **TouchEvent forwarding to id_viewer_overlay** — touch manager uses pointer events, not touch events


---

## What Remains

- **Typing slowness** — needs re-test on physical iPhone with keyboard fix in place; earlier observation may have been an artefact of the broken keyboard state
- **Context menu sheet** — appears on 500ms timer after cursor placement; visualViewport guard suppresses it when keyboard is fully up, but may still appear if keyboard is only partially shown at 500ms mark
- **Simulator testing** — always verify keyboard behaviour on a physical device; Simulator with software keyboard off looks identical to a real UIKit dismissal bug
- **Cell/Slide editors** — ContentEditableDiv keyboard fix is gated to Word only (`editorId === Word`); cell and slide have different canvas z-index layouts and forwarding targets that have not been validated


---

## Resolved Regressions

### ~~FAB hidden in Nextcloud iOS app~~ — FIXED in web-apps PR #74 (not an sdkjs regression)

The FAB regression was caused by a CSS cascade change in web-apps (static LESS import reversed load order, letting framework7's `.fab{z-index:1500}` override the app's `.fab{z-index:10000}`), plus a scroll handler firing during init. Fixed in [web-apps PR #74](https://github.com/Euro-Office/web-apps/pull/74) via a `userHasScrolled` ref guard in `Toolbar.jsx` and a `.page .fab` specificity bump in `app.less`. No sdkjs changes required.

</details>