### PR TITLE
Fix invisible first column in mid-page continuous multi-column sections

### DIFF
--- a/tests/runAll.js
+++ b/tests/runAll.js
@@ -50,6 +50,7 @@ const allTests = [
 	'word/custom-xml/custom-xml.html',
 	'word/document-calculation/floating-position/drawing.html',
 	'word/document-calculation/paragraph.html',
+	'word/document-calculation/multi-column-sections.html',
 	'word/document-calculation/table/correctBadTable.html',
 	'word/document-calculation/table/flowTablePosition.html',
 	'word/document-calculation/table/pageBreak.html',

--- a/tests/word/document-calculation/multi-column-sections.html
+++ b/tests/word/document-calculation/multi-column-sections.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<title>Multi-column section tests</title>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+		<link type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/qunit/2.16.0/qunit.css" rel="stylesheet" media="screen" />
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/qunit/2.16.0/qunit.js"></script>
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/xregexp/3.2.0/xregexp-all.min.js"></script>
+		<script type="text/javascript" src="../../../develop/sdkjs/word/scripts.js"></script>
+		<script type="text/javascript">
+			window.sdk_scripts.forEach(function(item){ document.write('<script type="text/javascript" src="' + item + '"><\/script>'); });
+		</script>
+		<script type="text/javascript" src="../common/common.js"></script>
+		<script type="text/javascript" src="../common/editor.js"></script>
+		<script type="text/javascript" src="../common/document.js"></script>
+		<script type="text/javascript" src="../common/measurer.js"></script>
+		<script type="text/javascript" src="multi-column-sections.js"></script>
+	</head>
+	<body>
+		<h1 id="qunit-header">Multi-column sections</h1>
+		<h2 id="qunit-banner"></h2>
+		<ol id="qunit-tests"></ol>
+		<div id="qunit-fixture">test markup</div>
+	</body>
+</html>

--- a/tests/word/document-calculation/multi-column-sections.js
+++ b/tests/word/document-calculation/multi-column-sections.js
@@ -1,0 +1,106 @@
+"use strict";
+
+// Regression test for the "invisible first column" bug in continuous multi-column
+// sections that start mid-page (Euro-Office / ONLYOFFICE bug #73801): when such a
+// section overflows onto the next page, recalculation re-enters it via
+// recalcresult_PrevPage, which re-Init()s the section (rebuilding every column) and
+// then resumed mid-section, leaving column 0 permanently empty -- its text remained
+// selectable but was never painted.
+
+$(function ()
+{
+	const logicDocument = AscTest.CreateLogicDocument();
+
+	// The shared test measurer reports a fixed line height regardless of font size,
+	// which flattens the vertical geometry and hides this layout bug (it only triggers
+	// at certain mid-page start positions). Use a measurer whose metrics scale with the
+	// font size so the column flow matches a real render.
+	function useProportionalMeasurer()
+	{
+		const tm = window.g_oTextMeasurer || AscCommon.g_oTextMeasurer;
+		let size = 10;
+		tm.SetTextPr       = function(tp){ if (tp && (tp.FontSize || tp.FontSizeCS)) size = tp.FontSize || tp.FontSizeCS; };
+		tm.SetFontSlot     = function(){};
+		tm.SetFont         = function(f){ if (f && f.FontSize) size = f.FontSize; };
+		tm.SetFontInternal = function(){};
+		tm.GetHeight       = function(){ return size * 0.6; };
+		tm.GetAscender     = function(){ return size * 0.46; };
+		tm.GetDescender    = function(){ return size * 0.14; };
+		tm.MeasureCode     = function(){ return { Width : size * 0.5 }; };
+		tm.Measure         = function(){ return { Width : size * 0.5 }; };
+		tm.Measure2Code    = function(){ return { Width : size * 0.5 }; };
+	}
+
+	function setupPage(sectPr)
+	{
+		sectPr.SetPageSize(210, 297);
+		sectPr.SetPageMargins(25, 25, 25, 25);
+	}
+
+	function getTwoColumnSectionOnPage(nPage)
+	{
+		const page = logicDocument.Pages[nPage];
+		if (!page) return null;
+		for (let i = 0; i < page.Sections.length; ++i)
+		{
+			const sec = page.Sections[i];
+			if (sec.Columns && sec.Columns.length === 2 && sec.YLimit - sec.Y > 1)
+				return sec;
+		}
+		return null;
+	}
+
+	QUnit.test("Column 0 of a mid-page 2-column section that overflows to the next page is not empty", function (assert)
+	{
+		AscTest.ClearDocument();
+		useProportionalMeasurer();
+
+		// Final (body) section: continuous, 2 equal columns.
+		let body = AscTest.GetFinalSection();
+		setupPage(body);
+		body.Set_Type(Asc.c_oAscSectionBreakType.Continuous);
+		body.Set_Columns_EqualWidth(true);
+		body.Set_Columns_Num(2);
+		body.Set_Columns_Space(8);
+
+		// First (top) section: full-width single column ending mid-page. Its height is
+		// what makes the 2-column section begin part-way down page 1 (the bug trigger).
+		let topSect = new AscWord.SectPr(logicDocument);
+		setupPage(topSect);
+		topSect.Set_Columns_EqualWidth(true);
+		topSect.Set_Columns_Num(1);
+
+		for (let i = 0; i < 4; ++i)
+		{
+			let p = AscTest.CreateParagraph();
+			AscTest.AddTextToParagraph(p, "Top line " + (i + 1));
+			if (i === 3)
+				p.Set_SectionPr(topSect);
+			logicDocument.PushToContent(p);
+		}
+
+		// Body: a long first paragraph (an "abstract") + more, so the 2-column section
+		// fills page 1 and overflows onto page 2 -- which triggers the PrevPage re-entry.
+		let abstract = AscTest.CreateParagraph();
+		AscTest.AddTextToParagraph(abstract, "Abstract - " + ("the abstract text should be a single paragraph with many words so that it wraps across many lines and naturally flows from the first column into the second column of the section. ").repeat(3));
+		logicDocument.PushToContent(abstract);
+		for (let i = 0; i < 12; ++i)
+		{
+			let p = AscTest.CreateParagraph();
+			AscTest.AddTextToParagraph(p, "Body paragraph " + (i + 1) + " with several words to add height to the column flow.");
+			logicDocument.PushToContent(p);
+		}
+
+		AscTest.Recalculate();
+
+		assert.ok(logicDocument.GetPagesCount() >= 2, "the section spans more than one page (got " + logicDocument.GetPagesCount() + ")");
+
+		const sec = getTwoColumnSectionOnPage(0);
+		assert.ok(!!sec, "a 2-column section exists on page 0");
+		if (!sec) return;
+
+		assert.strictEqual(sec.Columns[1].Empty, false, "column 1 has content");
+		assert.strictEqual(sec.Columns[0].Empty, false, "column 0 has content (regression: it was left empty)");
+		assert.ok(sec.Columns[0].EndPos >= sec.Columns[0].Pos, "column 0 draw range is non-empty");
+	});
+});

--- a/word/Editor/Document.js
+++ b/word/Editor/Document.js
@@ -4063,6 +4063,20 @@ CDocument.prototype.Recalculate_PageColumn                   = function()
             _bStart     = false;
 
 			let currPageSection = this.Pages[_PageIndex].Sections[_SectionIndex];
+
+			// Init() rebuilds every column of this section from scratch, discarding any
+			// already-computed column content. Therefore the recalculation has to restart
+			// from the section's first column; otherwise the columns before the resume
+			// point (_ColumnIndex) are left empty. This is what made column 0 of a
+			// continuous multi-column section that starts mid-page go blank while its text
+			// is still selectable (the "invisible first column" bug, ONLYOFFICE #73801).
+			// We capture the first column's start element before Init() wipes it.
+			if (currPageSection.Columns.length > 1 && _ColumnIndex > 0)
+			{
+				_ColumnIndex = 0;
+				_StartIndex  = currPageSection.Columns[0].Pos;
+			}
+
 			currPageSection.Init(_PageIndex, _sectPr, this.Layout.GetSectionIndex(_sectPr));
 			if (_SectionIndex > 0)
 			{


### PR DESCRIPTION
## Problem

In a **continuous multi-column section that starts mid-page** — the classic academic-paper layout (full-width title + authors, then a 2-column body via a *continuous* section break) — the **first (left) column renders blank** on the page where the section begins. The text is still there (it stays selectable, and editing a visible part brings it back), it just isn't painted. The bug also persists in exported PDFs.

This is the long-standing two-column "invisible text" issue: ONLYOFFICE/DocumentServer#3642, ONLYOFFICE/DesktopEditors#2197 (tracked internally as #73801), reproduced by several users and still open.

A telling property reported by users (and confirmed here): it **toggles with the height of the content above** the section — adding/removing a line in the top area flips the left column on and off — which points at the section's mid-page start position rather than the content itself.

## Root cause

In `CDocument.prototype.Recalculate_PageColumn` (`word/Editor/Document.js`), the `recalcresult_PrevPage` handler re-enters a section by calling `currPageSection.Init()`, which **rebuilds every column of the section from scratch**, discarding the already-computed column content. Recalculation then **resumed mid-section** (`_ColumnIndex` was left at the last column), so every column *before* the resume point — column 0 — was wiped and never re-filled. Its draw range ended up empty (`Pos=0 / EndPos=-1`), so the painter skipped it while the content remained in the document model — hence "selectable but invisible".

This path is only taken when a continuous multi-column section **starts part-way down a page** *and* **overflows onto the next page** (the overflow is what triggers the `PrevPage` re-entry), which is exactly why it depends on the height of the content above the section.

## Fix

When re-entering a multi-column section via `PrevPage`, restart the re-fill from **column 0** (capturing the first column's start element *before* `Init()` wipes it), so the whole section is recomputed rather than resumed mid-way. ~5 lines, in the `PrevPage` branch only.

## Testing

- Adds `tests/word/document-calculation/multi-column-sections.html` — builds a full-width section followed by a continuous 2-column section that overflows onto the next page, and asserts column 0 is not empty. **Fails before this change, passes after.** (The shared test measurer reports a fixed line height regardless of font size, which flattens the vertical geometry and hides the bug, so the test installs a font-size-proportional measurer — see the test comment.)
- Existing `document-calculation` / `paragraph` suites still pass.
- Verified end-to-end: the real reproduction document now renders both columns (in editor and in exported PDF).
