### PR TITLE
feat(cell): add Excel-style cell checkboxes

### DIFF
--- a/cell/api.js
+++ b/cell/api.js
@@ -6506,6 +6506,14 @@ var editor;
     this.wb.restoreFocus();
   };
 
+  spreadsheet_api.prototype.asc_insertCheckbox = function () {
+    if (this.collaborativeEditing.getGlobalLock() || !this.canEdit()) {
+      return;
+    }
+    this.wb.getWorksheet().setSelectionInfo("checkbox", true);
+    this.wb.restoreFocus();
+  };
+
 	spreadsheet_api.prototype.asc_checkProtectedRange = function () {
 		var ws = this.wbModel.getActiveWs();
 		/*if (!ws.isLockedActiveCell()) {
@@ -10340,6 +10348,7 @@ var editor;
   prot["asc_setCellFontName"] = prot.asc_setCellFontName;
   prot["asc_setCellFontSize"] = prot.asc_setCellFontSize;
   prot["asc_setCellBold"] = prot.asc_setCellBold;
+  prot["asc_insertCheckbox"] = prot.asc_insertCheckbox;
   prot["asc_setCellItalic"] = prot.asc_setCellItalic;
   prot["asc_setCellUnderline"] = prot.asc_setCellUnderline;
   prot["asc_setCellStrikeout"] = prot.asc_setCellStrikeout;

--- a/cell/model/History.js
+++ b/cell/model/History.js
@@ -153,6 +153,7 @@ function (window, undefined) {
 	window['AscCH'].historyitem_RowCol_Locked = 23;
 	window['AscCH'].historyitem_RowCol_HiddenFormulas = 24;
 	window['AscCH'].historyitem_RowCol_ReadingOrder = 25;
+	window['AscCH'].historyitem_RowCol_Checkbox = 26;
 
 	window['AscCH'].historyitem_Cell_Fontname = 1;
 	window['AscCH'].historyitem_Cell_Fontsize = 2;
@@ -184,6 +185,7 @@ function (window, undefined) {
 	window['AscCH'].historyitem_Cell_SetHidden = 29;
 	window['AscCH'].historyitem_Cell_SetLocked = 30;
 	window['AscCH'].historyitem_Cell_ReadingOrder = 31;
+	window['AscCH'].historyitem_Cell_SetCheckbox = 32;
 
 	window['AscCH'].historyitem_Comment_Add = 1;
 	window['AscCH'].historyitem_Comment_Remove = 2;

--- a/cell/model/Serialize.js
+++ b/cell/model/Serialize.js
@@ -215,7 +215,8 @@
         QuotePrefix: 11,
         XfId: 12,
         Aligment: 13,
-        Protection: 14
+        Protection: 14,
+        Checkbox: 15
     };
 	var c_oSerProtectionTypes =
     {
@@ -2112,6 +2113,7 @@
 		this.applyProtection = null;
 		this.locked = null;
 		this.hidden = null;
+		this.checkbox = null;
 	}
 
 	function ReadColorSpreadsheet2(bcr, length) {
@@ -3449,6 +3451,12 @@
 					this.memory.WriteByte(c_oSerPropLenType.Variable);
 					this.bs.WriteItemWithLength(function(){oThis.WriteProtection(xf);});
                 }
+				if(null != xf.checkbox)
+				{
+					this.memory.WriteByte(c_oSerXfsTypes.Checkbox);
+					this.memory.WriteByte(c_oSerPropLenType.Byte);
+					this.memory.WriteBool(xf.checkbox);
+				}
             }
         };
 		this.WriteProtection = function(xf)
@@ -9124,6 +9132,8 @@
 					return oThis.ReadProtection(t,l,oXfs);
 				});
 			}
+			else if ( c_oSerXfsTypes.Checkbox == type )
+				oXfs.checkbox = this.stream.GetBool();
             else
                 res = c_oSerConstants.ReadUnknown;
             return res;
@@ -14600,6 +14610,9 @@
 					newXf.locked = oStyleObject.xfs.locked;
                 if(null != oStyleObject.xfs.applyProtection)
                     newXf.applyProtection = oStyleObject.xfs.applyProtection;
+				// checkbox
+				if(null != oStyleObject.xfs.checkbox)
+					newXf.checkbox = oStyleObject.xfs.checkbox;
                 // align
                 if(null != oStyleObject.xfs.align)
 					newXf.align = g_StyleCache.addAlign(oStyleObject.xfs.align);
@@ -15210,6 +15223,9 @@
                 newXf.locked = oCellStyleXfs.locked;
             if(null != oCellStyleXfs.applyProtection)
                 newXf.applyProtection = oCellStyleXfs.applyProtection;
+            // checkbox
+            if(null != oCellStyleXfs.checkbox)
+                newXf.checkbox = oCellStyleXfs.checkbox;
             // align
             if(null != oCellStyleXfs.align)
                 newXf.align = oCellStyleXfs.align;
@@ -15290,6 +15306,9 @@
                 newXf.locked = xfs.locked;
             if(null != xfs.applyProtection)
                 newXf.applyProtection = xfs.applyProtection;
+            // checkbox
+            if(null != xfs.checkbox)
+                newXf.checkbox = xfs.checkbox;
             if(null != xfs.align)
                 newXf.align = xfs.align;
             if (null !== xfs.XfId) {

--- a/cell/model/UndoRedo.js
+++ b/cell/model/UndoRedo.js
@@ -3382,6 +3382,8 @@ function (window, undefined) {
 				cell.setLocked(Val);
 			} else if (AscCH.historyitem_Cell_SetHidden == Type) {
 				cell.setHiddenFormulas(Val);
+			} else if (AscCH.historyitem_Cell_SetCheckbox == Type) {
+				cell.setCheckbox(Val);
 			}
 		});
 	};
@@ -4819,6 +4821,8 @@ function (window, undefined) {
 				row.setLocked(Val);
 			} else if (AscCH.historyitem_RowCol_HiddenFormulas == Type) {
 				row.setHiddenFormulas(Val);
+			} else if (AscCH.historyitem_RowCol_Checkbox == Type) {
+				row.setCheckbox(Val);
 			}
 		}
 

--- a/cell/model/Workbook.js
+++ b/cell/model/Workbook.js
@@ -16058,6 +16058,14 @@
 		if(AscCommon.History.Is_On() && oRes.oldVal != oRes.newVal)
 			AscCommon.History.Add(AscCommonExcel.g_oUndoRedoCell, AscCH.historyitem_Cell_SetPivotButton, this.ws.getId(), new Asc.Range(this.nCol, this.nRow, this.nCol, this.nRow), new UndoRedoData_CellSimpleData(this.nRow, this.nCol, oRes.oldVal, oRes.newVal));
 	};
+	Cell.prototype.setCheckbox=function(val){
+		var oRes = this.ws.workbook.oStyleManager.setCheckbox(this, val);
+		if(AscCommon.History.Is_On() && oRes.oldVal != oRes.newVal)
+			AscCommon.History.Add(AscCommonExcel.g_oUndoRedoCell, AscCH.historyitem_Cell_SetCheckbox, this.ws.getId(), new Asc.Range(this.nCol, this.nRow, this.nCol, this.nRow), new UndoRedoData_CellSimpleData(this.nRow, this.nCol, oRes.oldVal, oRes.newVal));
+	};
+	Cell.prototype.getCheckbox=function(){
+		return !!(this.xfs && this.xfs.getCheckbox());
+	};
 	Cell.prototype.setStyle=function(xfs){
 		var oldVal = this.xfs;
 		this.setStyleInternal(xfs);
@@ -19744,6 +19752,34 @@
 		}, function (cell) {
 			cell.setHiddenFormulas(val);
 		});
+	};
+	Range.prototype.setCheckbox = function (val) {
+		AscCommon.History.Create_NewPoint();
+		this.createCellOnRowColCross();
+		var fSetProperty = this._setProperty;
+		var nRangeType = this._getRangeType();
+		if (c_oRangeType.All == nRangeType) {
+			this.worksheet.getAllCol().setCheckbox(val);
+			fSetProperty = this._setPropertyNoEmpty;
+		}
+		fSetProperty.call(this, function (row) {
+			if (c_oRangeType.All == nRangeType && null == row.xfs) {
+				return;
+			}
+			row.setCheckbox(val);
+		}, function (col) {
+			col.setCheckbox(val);
+		}, function (cell) {
+			cell.setCheckbox(val);
+		});
+	};
+	Range.prototype.getCheckbox = function () {
+		let res = false;
+		this.worksheet._getCellNoEmpty(this.bbox.r1, this.bbox.c1, function(cell) {
+			if (null != cell && cell.getCheckbox())
+				res = true;
+		});
+		return res;
 	};
 	Range.prototype.setType=function(type){
 		AscCommon.History.Create_NewPoint();

--- a/cell/model/WorkbookElems.js
+++ b/cell/model/WorkbookElems.js
@@ -4510,7 +4510,8 @@ var g_oFontProperties = {
         PivotButton: 7,
 		applyProtection: 8,
 		hidden: 9,
-		locked: 10
+		locked: 10,
+		checkbox: 11
     };
 
     /** @constructor */
@@ -4527,6 +4528,7 @@ var g_oFontProperties = {
         this.applyProtection = null;
         this.locked = null;
         this.hidden = null;
+        this.checkbox = null;
 
         //inner
         this._hash;
@@ -4548,6 +4550,7 @@ var g_oFontProperties = {
             this._hash += this.applyProtection + '|';
             this._hash += this.locked + '|';
             this._hash += this.hidden + '|';
+            this._hash += this.checkbox + '|';
         }
         return this._hash;
     };
@@ -4631,6 +4634,7 @@ var g_oFontProperties = {
             cache.applyProtection = this._mergeProperty(null, xfs.applyProtection, this.applyProtection);
             cache.locked = this._mergeProperty(null, xfs.locked, this.locked);
             cache.hidden = this._mergeProperty(null, xfs.hidden, this.hidden);
+            cache.checkbox = this._mergeProperty(null, xfs.checkbox, this.checkbox);
             cache = g_StyleCache.addXf(cache);
             this.setOperationCache("merge", xfIndexNumber, cache);
         }
@@ -4655,6 +4659,7 @@ var g_oFontProperties = {
         res.applyProtection = this.applyProtection;
         res.locked = this.locked;
         res.hidden = this.hidden;
+        res.checkbox = this.checkbox;
 
         return res;
     };
@@ -4662,7 +4667,7 @@ var g_oFontProperties = {
 		return this.font === xfs.font && this.fill === xfs.fill && this.border === xfs.border && this.num === xfs.num &&
 			this.align === xfs.align && this.QuotePrefix === xfs.QuotePrefix && this.PivotButton === xfs.PivotButton &&
 			this.XfId === xfs.XfId && this.applyProtection === xfs.applyProtection && this.locked === xfs.locked &&
-			this.hidden === xfs.hidden;
+			this.hidden === xfs.hidden && this.checkbox === xfs.checkbox;
     };
     CellXfs.prototype.getType = function () {
         return UndoRedoDataTypes.StyleXfs;
@@ -4694,6 +4699,8 @@ var g_oFontProperties = {
                 return this.locked;
             case this.Properties.hidden:
                 return this.hidden;
+            case this.Properties.checkbox:
+                return this.checkbox;
         }
     };
     CellXfs.prototype.setProperty = function (nType, value) {
@@ -4730,6 +4737,9 @@ var g_oFontProperties = {
                 break;
             case this.Properties.hidden:
                 this.hidden = value;
+                break;
+            case this.Properties.checkbox:
+                this.checkbox = value;
                 break;
         }
     };
@@ -4826,6 +4836,12 @@ var g_oFontProperties = {
     };
     CellXfs.prototype.setPivotButton = function (val) {
         this.PivotButton = val;
+    };
+    CellXfs.prototype.getCheckbox = function () {
+        return this.checkbox;
+    };
+    CellXfs.prototype.setCheckbox = function (val) {
+        this.checkbox = val;
     };
     CellXfs.prototype.getXfId = function () {
         return this.XfId;
@@ -5621,6 +5637,10 @@ StyleManager.prototype =
 	setPivotButton : function(oItemWithXfs, val)
 	{
 		return this._setProperty(oItemWithXfs, val, "pivotButton", CellXfs.prototype.getPivotButton, CellXfs.prototype.setPivotButton);
+	},
+	setCheckbox : function(oItemWithXfs, val)
+	{
+		return this._setProperty(oItemWithXfs, val, "checkbox", CellXfs.prototype.getCheckbox, CellXfs.prototype.setCheckbox);
 	},
 	setFontname : function(oItemWithXfs, val)
 	{
@@ -6655,6 +6675,13 @@ StyleManager.prototype =
 				this._getUpdateRange(), new UndoRedoData_IndexSimpleProp(this.index, true, oRes.oldVal, oRes.newVal));
 		}
 	};
+	Col.prototype.setCheckbox = function (val) {
+		var oRes = this.ws.workbook.oStyleManager.setCheckbox(this, val);
+		if (AscCommon.History.Is_On() && oRes.oldVal != oRes.newVal) {
+			AscCommon.History.Add(AscCommonExcel.g_oUndoRedoCol, AscCH.historyitem_RowCol_Checkbox, this.ws.getId(),
+				this._getUpdateRange(), new UndoRedoData_IndexSimpleProp(this.index, false, oRes.oldVal, oRes.newVal));
+		}
+	};
 	Col.prototype.setHidden = function (val) {
 		if (this.index >= 0 && (!this.hd !== !val)) {
 			this.ws.hiddenManager.addHidden(false, this.index);
@@ -7061,6 +7088,13 @@ StyleManager.prototype =
 		var oRes = this.ws.workbook.oStyleManager.setHiddenFormulas(this, val);
 		if (AscCommon.History.Is_On() && oRes.oldVal != oRes.newVal) {
 			AscCommon.History.Add(AscCommonExcel.g_oUndoRedoRow, AscCH.historyitem_RowCol_HiddenFormulas, this.ws.getId(),
+				this._getUpdateRange(), new UndoRedoData_IndexSimpleProp(this.index, true, oRes.oldVal, oRes.newVal));
+		}
+	};
+	Row.prototype.setCheckbox = function (val) {
+		var oRes = this.ws.workbook.oStyleManager.setCheckbox(this, val);
+		if (AscCommon.History.Is_On() && oRes.oldVal != oRes.newVal) {
+			AscCommon.History.Add(AscCommonExcel.g_oUndoRedoRow, AscCH.historyitem_RowCol_Checkbox, this.ws.getId(),
 				this._getUpdateRange(), new UndoRedoData_IndexSimpleProp(this.index, true, oRes.oldVal, oRes.newVal));
 		}
 	};

--- a/cell/view/EventsController.js
+++ b/cell/view/EventsController.js
@@ -1219,6 +1219,10 @@
 							oThis.handlers.trigger("selectRowsByRange");
 							nRetValue = keydownresult_PreventAll;
 						}
+						if (!bIsSelectColumns && !bIsSelect && oThis.canEdit() &&
+							oThis.handlers.trigger("toggleActiveCellCheckbox")) {
+							nRetValue = keydownresult_PreventAll;
+						}
 						break;
 					case 33: // PageUp
 						nDeltaRow = -0.5;
@@ -1765,7 +1769,9 @@
 						return;
 					} else if (t.targetInfo.target === c_oTargetType.FilterObject) {
 						if (0 === button) {
-							if (t.targetInfo.isDataValidation) {
+							if (t.targetInfo.isCheckbox) {
+								this.handlers.trigger("checkboxClick", t.targetInfo.col, t.targetInfo.row);
+							} else if (t.targetInfo.isDataValidation) {
 								this.handlers.trigger('onDataValidation');
 							} else if (t.targetInfo.idPivot) {
 								this.handlers.trigger("pivotFiltersClick", t.targetInfo.idPivot);

--- a/cell/view/WorkbookView.js
+++ b/cell/view/WorkbookView.js
@@ -493,6 +493,10 @@
 				  self._onPivotFiltersClick.apply(self, arguments);
 			  }, "pivotCollapseClick": function () {
 				  self._onPivotCollapseClick.apply(self, arguments);
+			  }, "checkboxClick": function () {
+				  self._onCheckboxClick.apply(self, arguments);
+			  }, "toggleActiveCellCheckbox": function () {
+				  return self.getWorksheet().toggleActiveCellCheckbox();
 			  }, "refreshConnections": function () {
 				  return self._onRefreshConnections.apply(self, arguments);
 			  }, "commentCellClick": function () {
@@ -2001,6 +2005,13 @@
       return;
     }
     pivotTable.setVisibleFieldItem(this.Api, !idPivotCollapse.sd, idPivotCollapse.fld, idPivotCollapse.index);
+  };
+
+  WorkbookView.prototype._onCheckboxClick = function(col, row) {
+    var ws = this.getWorksheet();
+    if (ws) {
+      ws.toggleCheckbox(col, row);
+    }
   };
 
   WorkbookView.prototype._onRefreshConnections = function(isAll) {

--- a/cell/view/WorksheetView.js
+++ b/cell/view/WorksheetView.js
@@ -6674,6 +6674,10 @@ function isAllowPasteLink(pastedWb) {
 			if (clipUse) {
 				this._RemoveClipRect(ctx);
 			}
+		} else if (this._isCheckboxCell(c)) {
+			this._AddClipRect(ctx, x1, y1, w, h);
+			this._drawCellCheckbox(ctx, col, row, offsetX, offsetY);
+			this._RemoveClipRect(ctx);
 		} else {
 			this._AddClipRect(ctx, x1, y1, w, h);
 			if (this._getCellCF(cfIterator, c, row, col, Asc.ECfType.iconSet) /*&& AscCommon.align_Left === ct.cellHA*/) {
@@ -6730,6 +6734,132 @@ function isAllowPasteLink(pastedWb) {
 		}
 
 		return null;
+	};
+
+	WorksheetView.prototype._isCheckboxCell = function (c) {
+		// c comes from _getVisibleCell (getCell3 -> getRange3), i.e. a Range, not a Cell:
+		// use the Range compiled-style accessor (getXfs(true)), not Cell.getCompiledStyle.
+		if (!c || CellValueType.Bool !== c.getType()) {
+			return false;
+		}
+		var xfs = c.getXfs(true);
+		return !!(xfs && xfs.checkbox);
+	};
+
+	WorksheetView.prototype._getCheckboxRect = function (col, row, offsetX, offsetY) {
+		var ct = this._getCellTextCache(col, row);
+		if (!ct || ct.angle) {
+			return null;
+		}
+
+		var isMerged = ct.flags.isMerged(), range;
+		var rowB = row, colR = col;
+		if (isMerged) {
+			range = ct.flags.merged;
+			if (col !== range.c1 || row !== range.r1) {
+				return null;
+			}
+			colR = Math.min(range.c2, this.nColsCount - 1);
+			rowB = Math.min(range.r2, this.nRowsCount - 1);
+		}
+
+		var y1 = this._getRowTop(row) - offsetY;
+		var h = this._getRowTop(rowB + 1) - offsetY - y1;
+		var bl = y1 + h - Asc.round(
+			(isMerged ? (ct.metrics.height - ct.metrics.baseline) : this._getRowDescender(rowB)) * this.getZoom());
+		var x1ct = this._getColLeft(col) - offsetX;
+		var x2ct = isMerged ? (this._getColLeft(colR + 1) - offsetX - gridlineSize) :
+			(x1ct + this._getColumnWidth(col) - gridlineSize);
+
+		var textH = ct.metrics.height * this.getZoom();
+		var side = Math.max(5, Math.min(Asc.round(textH * 0.7), h - 2));
+		var bx = this._calcTextHorizPos(x1ct, x2ct, {width: side}, ct.cellHA, true);
+		var by = this._calcTextVertPos(y1, h, bl, ct.metrics, ct.cellVA) + Asc.round((textH - side) / 2);
+
+		return {x: bx, y: by, side: side};
+	};
+
+	WorksheetView.prototype._drawCellCheckbox = function (ctx, col, row, offsetX, offsetY) {
+		var rect = this._getCheckboxRect(col, row, offsetX, offsetY);
+		if (!rect) {
+			return;
+		}
+
+		var c = this._getVisibleCell(col, row);
+		var checked = 1 === c.getNumberValue();
+		var lineW = Math.max(1, Asc.round(rect.side / 9));
+
+		if (checked) {
+			ctx.setFillStyle(new CColor(33, 115, 70));
+			this._fillRect(ctx, rect.x, rect.y, rect.side, rect.side);
+
+			ctx.beginPath();
+			ctx.setLineWidth(lineW);
+			ctx.setStrokeStyle(new CColor(255, 255, 255));
+			this._moveTo(ctx, rect.x + 0.22 * rect.side, rect.y + 0.55 * rect.side);
+			this._lineTo(ctx, rect.x + 0.42 * rect.side, rect.y + 0.74 * rect.side);
+			this._lineTo(ctx, rect.x + 0.78 * rect.side, rect.y + 0.3 * rect.side);
+			ctx.stroke();
+		} else {
+			ctx.beginPath();
+			ctx.setLineWidth(lineW);
+			ctx.setStrokeStyle(this.settings.cells.defaultState.border);
+			this._strokeRect(ctx, rect.x + 0.5, rect.y + 0.5, rect.side - 1, rect.side - 1);
+		}
+	};
+
+	WorksheetView.prototype._hitCheckboxCell = function (x, y, col, row) {
+		var merged = this.model.getMergedByCell(row, col);
+		if (merged) {
+			col = merged.c1;
+			row = merged.r1;
+		}
+		var c = this._getVisibleCell(col, row);
+		if (!this._isCheckboxCell(c) || c.isFormula()) {
+			return false;
+		}
+		var rect = this._getCheckboxRect(col, row, 0, 0);
+		return !!rect && x >= rect.x && x <= rect.x + rect.side && y >= rect.y && y <= rect.y + rect.side;
+	};
+
+	WorksheetView.prototype.toggleCheckbox = function (col, row) {
+		var t = this;
+		if (!this.workbook.canEdit()) {
+			return false;
+		}
+		var merged = this.model.getMergedByCell(row, col);
+		if (merged) {
+			col = merged.c1;
+			row = merged.r1;
+		}
+		var c = this._getVisibleCell(col, row);
+		if (!this._isCheckboxCell(c) || c.isFormula()) {
+			return false;
+		}
+		var checked = 1 === c.getNumberValue();
+		var range = merged || new asc_Range(col, row, col, row);
+		this._isLockedCells(range, null, function (success) {
+			if (!success) {
+				return;
+			}
+			var oCellValue = new AscCommonExcel.CCellValue();
+			oCellValue.type = CellValueType.Bool;
+			oCellValue.number = checked ? 0 : 1;
+			t.model.getRange3(row, col, row, col).setValueData(
+				new AscCommonExcel.UndoRedoData_CellValueData(null, oCellValue));
+			t._updateRange(range);
+			t.draw();
+		});
+		return true;
+	};
+
+	WorksheetView.prototype.toggleActiveCellCheckbox = function () {
+		var activeCell = this.model.getSelection().activeCell;
+		var c = this._getVisibleCell(activeCell.col, activeCell.row);
+		if (!this._isCheckboxCell(c) || c.isFormula()) {
+			return false;
+		}
+		return this.toggleCheckbox(activeCell.col, activeCell.row);
 	};
 
 	WorksheetView.prototype._drawPageBreakPreviewLines = function () {
@@ -12412,6 +12542,10 @@ function isAllowPasteLink(pastedWb) {
 					if (_vr.contains(c.col, r.row)) {
 						_offsetX += x;
 						_offsetY += y;
+						if (this._hitCheckboxCell(_offsetX, _offsetY, c.col, r.row)) {
+							res = {cursor: kCurHyperlink, target: c_oTargetType.FilterObject, col: c.col, row: r.row, isCheckbox: true};
+							return false;
+						}
 						if (isDataValidation) {
 							var merged = this.model.getMergedByCell(row, col);
 							if (merged) {
@@ -16494,6 +16628,31 @@ function isAllowPasteLink(pastedWb) {
 						break;
 					case "hiddenFormulas":
 						range.setHiddenFormulas(val);
+						break;
+					case "checkbox":
+						range.setCheckbox(val);
+						if (val) {
+							//like Excel: blank cells in the selection become unchecked checkboxes
+							var emptyValue = new AscCommonExcel.CCellValue();
+							emptyValue.type = CellValueType.Bool;
+							emptyValue.number = 0;
+							var emptyData = new AscCommonExcel.UndoRedoData_CellValueData(null, emptyValue);
+							//clamp huge (full row/col) selections to the used area
+							var fillR2 = range.bbox.r2, fillC2 = range.bbox.c2;
+							if (isLargeRange) {
+								fillR2 = Math.min(fillR2, t.model.getRowsCount() - 1);
+								fillC2 = Math.min(fillC2, t.model.getColsCount() - 1);
+							}
+							for (var checkboxRow = range.bbox.r1; checkboxRow <= fillR2; ++checkboxRow) {
+								for (var checkboxCol = range.bbox.c1; checkboxCol <= fillC2; ++checkboxCol) {
+									t.model._getCell(checkboxRow, checkboxCol, function (checkboxCell) {
+										if (checkboxCell.isNullTextString() && !checkboxCell.isFormula()) {
+											checkboxCell.setValueData(emptyData);
+										}
+									});
+								}
+							}
+						}
 						break;
                     case "rh":
                         range.removeHyperlink(null, true);


### PR DESCRIPTION
Adds Excel-style cell checkboxes to the spreadsheet SDK.

- New `checkbox` flag on the cell xf: model, binary serialization (`c_oSerXfsTypes.Checkbox`), history/undo-redo.
- Render boolean checkbox cells as a clickable glyph in the draw path; toggle on click and on Space (read-only/formula cells excluded).
- `asc_insertCheckbox` applies the format to the selection and sets blank cells to FALSE, in one history transaction.

Verified live: checkbox cells render, click and Space toggle TRUE↔FALSE, undo works. Caught and fixed a crash where the draw path passes a Range (not a Cell) to the checkbox check — uses `getXfs(true)` instead of the Cell-only `getCompiledStyle()`.

Note: independent/alternative implementation; an existing `feature/checkbox` branch also implements this. Opened for comparison.