### PR TITLE
build: default closure level to WHITESPACE_ONLY

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -180,7 +180,7 @@ module.exports = function(grunt) {
 	const slide = path.join(deploy, 'slide');
 	const visio = path.join(deploy, 'visio');
 
-	const level = grunt.option('level') || 'ADVANCED';
+	const level = grunt.option('level') || 'WHITESPACE_ONLY';
 	const formatting = grunt.option('formatting') || '';
 
 	const ccPlatform = process.env.CC_PLATFORM


### PR DESCRIPTION
Changes the default Closure Compiler `level` from `ADVANCED` to `WHITESPACE_ONLY`. Avoids aggressive renaming/inlining by default, keeping minified SDK output readable for debugging. Can still be overridden with `--level=ADVANCED`.