### PR TITLE
Fix LICENSE link in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,4 +27,4 @@ The directory layout below helps developers quickly navigate and understand SDKJ
 
 ## 📜 License
 
-**SDKJS** is licensed under the **GNU Affero General Public License (AGPL) v3.0**. For full details, refer to the [LICENSE](https://github.com/Euro-Office/sdkjs/blob/master/LICENSE.txt) file.
+**SDKJS** is licensed under the **GNU Affero General Public License (AGPL) v3.0**. For full details, refer to the [LICENSE](https://github.com/Euro-Office/sdkjs/blob/main/LICENSE.txt) file.


### PR DESCRIPTION
Updated the LICENSE link in the README file to point to the main branch.