### PR TITLE
feat(word): add visual pageless view mode

### DIFF
--- a/tests/runAll.js
+++ b/tests/runAll.js
@@ -66,6 +66,7 @@ const allTests = [
 	'word/api/api.html',
 	'word/api/cross-ref.html',
 	'word/api/textInput.html',
+	'word/pageless/pageless.html',
 	'word/styles/displayStyle.html',
 	'word/styles/paraPr.html',
 	'word/styles/styleApplicator.html',

--- a/tests/word/pageless/pageless.html
+++ b/tests/word/pageless/pageless.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+    <title>Pageless view mode test</title>
+
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <link type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/qunit/2.16.0/qunit.css" rel="stylesheet" media="screen" />
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/qunit/2.16.0/qunit.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/xregexp/3.2.0/xregexp-all.min.js"></script>
+
+    <script type="text/javascript" src="../../../develop/sdkjs/word/scripts.js"></script>
+    <script type="text/javascript">
+		window.sdk_scripts.forEach(function(item){
+			document.write('<script type="text/javascript" src="' + item + '"><\/script>');
+		});
+    </script>
+
+    <script type="text/javascript" src="../common/common.js"></script>
+    <script type="text/javascript" src="../common/editor.js"></script>
+    <script type="text/javascript" src="../common/document.js"></script>
+    <script type="text/javascript" src="../common/measurer.js"></script>
+
+    <script type="text/javascript" src="pageless.js"></script>
+</head>
+<body>
+<h1 id="qunit-header">Test the pageless view mode of the document editor</h1>
+<h2 id="qunit-banner"></h2>
+<div id="qunit-testrunner-toolbar"></div>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests"></ol>
+<div id="qunit-fixture">test markup, will be hidden</div>
+</body>
+</html>

--- a/tests/word/pageless/pageless.js
+++ b/tests/word/pageless/pageless.js
@@ -1,0 +1,100 @@
+/*
+ * (c) Copyright Ascensio System SIA 2010-2024
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation. In accordance with
+ * Section 7(a) of the GNU AGPL its Section 15 shall be amended to the effect
+ * that Ascensio System SIA expressly excludes the warranty of non-infringement
+ * of any third-party rights.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR  PURPOSE. For
+ * details, see the GNU AGPL at: http://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * The  interactive user interfaces in modified source and object code versions
+ * of the Program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * All the Product's GUI elements, including illustrations and icon sets, as
+ * well as technical writing content are licensed under the terms of the
+ * Creative Commons Attribution-ShareAlike 4.0 International. See the License
+ * terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+ */
+
+$(function () {
+
+	const proto = AscCommon.DocumentEditorApi.prototype;
+
+	// Builds a minimal api-shaped object that exercises the real SetPagelessMode/
+	// GetPagelessMode implementations against an injected WordControl, recording the
+	// refresh side effects (cache clear + layout re-fire) the setter is expected to trigger.
+	function createApi() {
+		const calls = { clearCache : 0, zoomFire : 0 };
+		return {
+			_calls : calls,
+			SetPagelessMode : proto.SetPagelessMode,
+			GetPagelessMode : proto.GetPagelessMode,
+			WordControl : {
+				isPagelessMode    : false,
+				m_nZoomValue      : 100,
+				m_oEditor         : { HtmlElement : { fullRepaint : false } },
+				m_oDrawingDocument: { ClearCachePages : function () { calls.clearCache++; } },
+				zoom_Fire         : function () { calls.zoomFire++; }
+			}
+		};
+	}
+
+	QUnit.module("Test pageless view mode (api)");
+
+	QUnit.test("GetPagelessMode reflects the WordControl flag", function (assert) {
+		let api = createApi();
+		assert.strictEqual(api.GetPagelessMode(), false, "Off by default");
+		api.WordControl.isPagelessMode = true;
+		assert.strictEqual(api.GetPagelessMode(), true, "Reflects an enabled flag");
+	});
+
+	QUnit.test("GetPagelessMode is safe without a WordControl", function (assert) {
+		assert.strictEqual(proto.GetPagelessMode.call({ WordControl : null }), false, "Returns false, does not throw");
+	});
+
+	QUnit.test("SetPagelessMode enables the flag and refreshes the layout", function (assert) {
+		let api = createApi();
+		api.SetPagelessMode(true);
+		assert.strictEqual(api.WordControl.isPagelessMode, true, "Flag enabled");
+		assert.strictEqual(api.GetPagelessMode(), true, "Getter agrees");
+		assert.strictEqual(api.WordControl.m_oEditor.HtmlElement.fullRepaint, true, "Full repaint requested");
+		assert.strictEqual(api._calls.clearCache, 1, "Page cache cleared (outline is cached)");
+		assert.strictEqual(api._calls.zoomFire, 1, "Layout re-fired (collapses page gaps)");
+	});
+
+	QUnit.test("SetPagelessMode disables the flag again", function (assert) {
+		let api = createApi();
+		api.SetPagelessMode(true);
+		api.SetPagelessMode(false);
+		assert.strictEqual(api.GetPagelessMode(), false, "Flag disabled");
+		assert.strictEqual(api._calls.zoomFire, 2, "Layout re-fired on each real change");
+	});
+
+	QUnit.test("SetPagelessMode is a no-op when the value is unchanged", function (assert) {
+		let api = createApi();
+		api.SetPagelessMode(true);
+		api.SetPagelessMode(true);
+		assert.strictEqual(api._calls.clearCache, 1, "No extra cache clear");
+		assert.strictEqual(api._calls.zoomFire, 1, "No extra layout re-fire");
+	});
+
+	QUnit.test("SetPagelessMode coerces its argument to a boolean", function (assert) {
+		let api = createApi();
+		api.SetPagelessMode("yes");
+		assert.strictEqual(api.WordControl.isPagelessMode, true, "Truthy value stored as true");
+		api.SetPagelessMode(0);
+		assert.strictEqual(api.WordControl.isPagelessMode, false, "Falsy value stored as false");
+	});
+
+	QUnit.test("SetPagelessMode is safe without a WordControl", function (assert) {
+		proto.SetPagelessMode.call({ WordControl : null }, true);
+		assert.ok(true, "Does not throw when WordControl is missing");
+	});
+});

--- a/word/Drawing/DrawingDocument.js
+++ b/word/Drawing/DrawingDocument.js
@@ -1090,6 +1090,9 @@ CPage.prototype.Draw = function (context, xDst, yDst, wDst, hDst, api)
 		strokeColor = api.getPageStrokeColor();
 	}
 
+	if (api && api.WordControl && api.WordControl.isPagelessMode)
+		strokeColor = undefined;
+
 	if (strokeColor)
 	{
 		let lineW = Math.round(AscCommon.AscBrowser.retinaPixelRatio);

--- a/word/Drawing/HtmlPage.js
+++ b/word/Drawing/HtmlPage.js
@@ -144,6 +144,10 @@ function CEditorPage(api)
 
 	this.viewBetweenPagesHor = 20;
 	this.viewBetweenPagesVer = 20;
+	this.isPagelessMode = false;
+
+	this.getPageGapVer = function() { return this.isPagelessMode ? 0 : this.viewBetweenPagesVer; };
+	this.getPageGapHor = function() { return this.isPagelessMode ? 0 : this.viewBetweenPagesHor; };
 
 	// текущий зум после резайза. чтобы например после zoomToWidth и zoomIn/Out можно было вернуться на значение меньше меньшего/больше большего
 	this.m_nZoomValueMin = -1;
@@ -3104,7 +3108,7 @@ function CEditorPage(api)
 				if (_pageWidth > this.m_dDocumentWidth)
 					this.m_dDocumentWidth = _pageWidth;
 
-				this.m_dDocumentHeight += this.viewBetweenPagesVer;
+				this.m_dDocumentHeight += this.getPageGapVer();
 				this.m_dDocumentHeight += _pageHeight;
 			}
 		}
@@ -3120,7 +3124,7 @@ function CEditorPage(api)
 				if (currentBlockW > _this.m_dDocumentWidth)
 					_this.m_dDocumentWidth = currentBlockW;
 
-				_this.m_dDocumentHeight += _this.viewBetweenPagesVer;
+				_this.m_dDocumentHeight += _this.getPageGapVer();
 				_this.m_dDocumentHeight += currentBlockH;
 			};
 
@@ -3144,7 +3148,7 @@ function CEditorPage(api)
 					continue;
 				}
 
-				let testW = currentBlockW + this.viewBetweenPagesHor + _pageWidth;
+				let testW = currentBlockW + this.getPageGapHor() + _pageWidth;
 				if (testW > editorWidth)
 				{
 					_checkBlock(this);
@@ -3165,7 +3169,7 @@ function CEditorPage(api)
 				_checkBlock(this);
 		}
 
-		this.m_dDocumentHeight += this.viewBetweenPagesVer;
+		this.m_dDocumentHeight += this.getPageGapVer();
 
 		// теперь увеличим ширину документа, чтобы он не был плотно к краям
 		if (!this.m_oApi.isMobileVersion)
@@ -3249,12 +3253,12 @@ function CEditorPage(api)
 				let drawRect = this.m_oDrawingDocument.m_arrPages[i].drawingPage;
 
 				drawRect.left = hor_pos_median - (pageWidth >> 1);
-				drawRect.top = lStart + this.viewBetweenPagesVer - lCurrentTopInDoc;
+				drawRect.top = lStart + this.getPageGapVer() - lCurrentTopInDoc;
 				drawRect.right = drawRect.left + pageWidth;
 				drawRect.bottom = drawRect.top + pageHeight;
 				drawRect.pageIndex = i;
 
-				lStart += (this.viewBetweenPagesVer + pageHeight);
+				lStart += (this.getPageGapVer() + pageHeight);
 
 				if (false === bIsFoundFirst && drawRect.bottom > 0)
 				{
@@ -3281,7 +3285,7 @@ function CEditorPage(api)
 			let _checkBlock = function(_this) {
 
 				let left = hor_pos_median - (currentBlockW >> 1);
-				let top = lStart + _this.viewBetweenPagesVer - lCurrentTopInDoc;
+				let top = lStart + _this.getPageGapVer() - lCurrentTopInDoc;
 
 				for (let i = 0, len = currentBlockPages.length; i < len; i++)
 				{
@@ -3298,7 +3302,7 @@ function CEditorPage(api)
 					drawRect.bottom = drawRect.top + pageHeight;
 					drawRect.pageIndex = ind;
 
-					left = drawRect.right + _this.viewBetweenPagesHor;
+					left = drawRect.right + _this.getPageGapHor();
 
 					if (false === bIsFoundFirst && drawRect.bottom > 0)
 					{
@@ -3313,7 +3317,7 @@ function CEditorPage(api)
 					}
 				}
 
-				lStart += (_this.viewBetweenPagesVer + currentBlockH);
+				lStart += (_this.getPageGapVer() + currentBlockH);
 				currentBlockPages = [];
 			};
 
@@ -3330,7 +3334,7 @@ function CEditorPage(api)
 					continue;
 				}
 
-				let testW = currentBlockW + this.viewBetweenPagesHor + _pageWidth;
+				let testW = currentBlockW + this.getPageGapHor() + _pageWidth;
 				if (testW > editorWidth)
 				{
 					_checkBlock(this);

--- a/word/api.js
+++ b/word/api.js
@@ -8686,6 +8686,21 @@ background-repeat: no-repeat;\
 			this.WordControl.zoom_Fire(0, this.WordControl.m_nZoomValue);
 		}
 	};
+	asc_docs_api.prototype.GetPagelessMode = function() {
+		return !!(this.WordControl && this.WordControl.isPagelessMode);
+	};
+	asc_docs_api.prototype.SetPagelessMode = function(isPageless) {
+		if (!this.WordControl)
+			return;
+		isPageless = !!isPageless;
+		if (this.WordControl.isPagelessMode === isPageless)
+			return;
+		this.WordControl.isPagelessMode = isPageless;
+		if (this.WordControl.m_oEditor && this.WordControl.m_oEditor.HtmlElement)
+			this.WordControl.m_oEditor.HtmlElement.fullRepaint = true;
+		this.WordControl.m_oDrawingDocument.ClearCachePages();
+		this.WordControl.zoom_Fire(0, this.WordControl.m_nZoomValue);
+	};
 
 	asc_docs_api.prototype.asc_SetDocumentPlaceChangedEnabled = function(bEnabled)
 	{
@@ -15408,6 +15423,8 @@ background-repeat: no-repeat;\
 	asc_docs_api.prototype['GetCurrentVisiblePages']                    = asc_docs_api.prototype.GetCurrentVisiblePages;
 	asc_docs_api.prototype['SetMultipageViewMode']                      = asc_docs_api.prototype.SetMultipageViewMode;
 	asc_docs_api.prototype['GetMultipageViewMode']                      = asc_docs_api.prototype.GetMultipageViewMode;
+	asc_docs_api.prototype['SetPagelessMode']                           = asc_docs_api.prototype.SetPagelessMode;
+	asc_docs_api.prototype['GetPagelessMode']                           = asc_docs_api.prototype.GetPagelessMode;
 	asc_docs_api.prototype['asc_setAutoSaveGap']                        = asc_docs_api.prototype.asc_setAutoSaveGap;
 	asc_docs_api.prototype['asc_SetDocumentPlaceChangedEnabled']        = asc_docs_api.prototype.asc_SetDocumentPlaceChangedEnabled;
 	asc_docs_api.prototype['asc_SetViewRulers']                         = asc_docs_api.prototype.asc_SetViewRulers;


### PR DESCRIPTION
Pageless view for the Word editor (issue #2553).

Adds a per-view "pageless" flag that renders a multi-page document as one continuous sheet, without changing internal pagination. Mirrors the existing Multiple Pages view mode.

## Changes
- `WordControl` gains `isPagelessMode` plus `getPageGapVer()`/`getPageGapHor()` accessors that return `0` when pageless; the inter-page gap reads in `CalculateDocumentSize`/`OnCalculatePagesPlace` now go through them, collapsing the grey gaps.
- `CPage.Draw` skips the per-page outline (`strokeColor = undefined`) when pageless.
- Public API `SetPagelessMode`/`GetPagelessMode` (modelled on `Set/GetMultipageViewMode`); the setter clears the page cache and re-fires layout so the outline/gap change repaints.

## Notes
- View preference only — does not modify the document or affect collaborators.
- The UI toggle lives in the web-apps PR; this PR is the engine half.

<details>
<summary>True continuous reflow (future, out of scope here)</summary>

Documented now so Phase 1 doesn't paint us into a corner. The engine already has a **pluggable layout architecture** that is the right insertion point:
- `CDocumentLayoutBase` (`word/Editor/Layout/Base.js`) defines `GetPageContentFrame` / `GetColumnContentFrame`, whose `YLimit` is what forces content onto the next page.
  - Concrete layouts `CDocumentPrintView` and `CDocumentReadView` (`Layout/PrintView.js`, `Layout/ReadView.js`) are registered in `CDocument` at `Document.js:1207-1212` (`this.Layouts = {Print, Read}; this.Layout = this.Layouts.Print;`) and swapped via SetDocumentReadMode` (`Document.js:17049`).

Phase 2 would add `CDocumentPagelessView` returning a near-infinite `YLimit` (single ever-growing page, no page breaks), register it in `this.Layouts`, add a SetDocumentPagelessMode` swap method following `SetDocumentReadMode`, and decide header/footer and section-break handling. The Phase-1 API method (`SetPagelessMode`) can later route to this layout swap so the UI contract stays stable.

Deferred background colour would extend `getPageBackgroundColor` (`api.js:14248-14254`) plus a colour-picker control in `ViewTab`.
</details>