### PR TITLE
Misspell wavy line

### DIFF
--- a/cell/api.js
+++ b/cell/api.js
@@ -8695,6 +8695,21 @@ var editor;
 		this._spellCheckRestart();
   	}
   };
+  // Spreadsheets have no SpellCheckManager (cell-value spellcheck doesn't
+  // route through the shared paragraph/graphics pipeline), but shape text on
+  // a sheet does, via the shared AscCommon.CGraphics used for shape rendering.
+  // Store settings directly so CGraphics.IsSpellCheckWavyLine can read them.
+  spreadsheet_api.prototype.asc_setSpellCheckSettings = function(oSettings)
+  {
+  	this.spellCheckSettings = oSettings;
+  	this._spellCheckRestart();
+  };
+  spreadsheet_api.prototype.asc_getSpellCheckSettings = function()
+  {
+  	if (!this.spellCheckSettings)
+  		this.spellCheckSettings = new AscCommon.CSpellCheckSettings();
+  	return this.spellCheckSettings;
+  };
   spreadsheet_api.prototype.asc_ConvertEquationToMath = function(oEquation, isAll)
   {
       // TODO: Вообще здесь нужно запрашивать шрифты, которые использовались в старой формуле,
@@ -10380,6 +10395,8 @@ var editor;
   prot["asc_cancelSpellCheck"] = prot.asc_cancelSpellCheck;
   prot["asc_ignoreNumbers"] = prot.asc_ignoreNumbers;
   prot["asc_ignoreUppercase"] = prot.asc_ignoreUppercase;
+  prot["asc_setSpellCheckSettings"] = prot.asc_setSpellCheckSettings;
+  prot["asc_getSpellCheckSettings"] = prot.asc_getSpellCheckSettings;
   prot["asc_getKeyboardLanguage"] = prot.asc_getKeyboardLanguage;
   prot["asc_getInputLanguage"] = prot.asc_getInputLanguage;
 

--- a/cell/api.js
+++ b/cell/api.js
@@ -8695,21 +8695,6 @@ var editor;
 		this._spellCheckRestart();
   	}
   };
-  // Spreadsheets have no SpellCheckManager (cell-value spellcheck doesn't
-  // route through the shared paragraph/graphics pipeline), but shape text on
-  // a sheet does, via the shared AscCommon.CGraphics used for shape rendering.
-  // Store settings directly so CGraphics.IsSpellCheckWavyLine can read them.
-  spreadsheet_api.prototype.asc_setSpellCheckSettings = function(oSettings)
-  {
-  	this.spellCheckSettings = oSettings;
-  	this._spellCheckRestart();
-  };
-  spreadsheet_api.prototype.asc_getSpellCheckSettings = function()
-  {
-  	if (!this.spellCheckSettings)
-  		this.spellCheckSettings = new AscCommon.CSpellCheckSettings();
-  	return this.spellCheckSettings;
-  };
   spreadsheet_api.prototype.asc_ConvertEquationToMath = function(oEquation, isAll)
   {
       // TODO: Вообще здесь нужно запрашивать шрифты, которые использовались в старой формуле,
@@ -10395,8 +10380,6 @@ var editor;
   prot["asc_cancelSpellCheck"] = prot.asc_cancelSpellCheck;
   prot["asc_ignoreNumbers"] = prot.asc_ignoreNumbers;
   prot["asc_ignoreUppercase"] = prot.asc_ignoreUppercase;
-  prot["asc_setSpellCheckSettings"] = prot.asc_setSpellCheckSettings;
-  prot["asc_getSpellCheckSettings"] = prot.asc_getSpellCheckSettings;
   prot["asc_getKeyboardLanguage"] = prot.asc_getKeyboardLanguage;
   prot["asc_getInputLanguage"] = prot.asc_getInputLanguage;
 

--- a/common/api/spellCheckSettings.js
+++ b/common/api/spellCheckSettings.js
@@ -30,16 +30,18 @@
 	const FLAGS_MASK       = 0xFFFF;
 	const IGNORE_UPPERCASE = 0x0001;
 	const IGNORE_NUMBERS   = 0x0002;
+	const WAVY_LINE        = 0x0004;
 
 	const NON_IGNORE_UPPERCASE = FLAGS_MASK ^ IGNORE_UPPERCASE;
 	const NON_IGNORE_NUMBERS   = FLAGS_MASK ^ IGNORE_NUMBERS;
+	const NON_WAVY_LINE        = FLAGS_MASK ^ WAVY_LINE;
 
 	/**
 	 * @constructor
 	 */
 	function CSpellCheckSettings()
 	{
-		this.Flags = IGNORE_UPPERCASE | IGNORE_NUMBERS;
+		this.Flags = IGNORE_UPPERCASE | IGNORE_NUMBERS | WAVY_LINE;
 	}
 	CSpellCheckSettings.prototype.Copy = function()
 	{
@@ -73,6 +75,17 @@
 		else
 			this.Flags &= NON_IGNORE_NUMBERS;
 	};
+	CSpellCheckSettings.prototype.IsWavyLine = function()
+	{
+		return !!(this.Flags & WAVY_LINE);
+	};
+	CSpellCheckSettings.prototype.SetWavyLine = function(isWavy)
+	{
+		if (isWavy)
+			this.Flags |= WAVY_LINE;
+		else
+			this.Flags &= NON_WAVY_LINE;
+	};
 	//--------------------------------------------------------export----------------------------------------------------
 	window['AscCommon'] = window['AscCommon'] || {};
 	window['AscCommon'].CSpellCheckSettings = window['AscCommon']['CSpellCheckSettings'] = CSpellCheckSettings;
@@ -80,5 +93,7 @@
 	CSpellCheckSettings.prototype['put_IgnoreWordsInUppercase'] = CSpellCheckSettings.prototype.put_IgnoreWordsInUppercase = CSpellCheckSettings.prototype.SetIgnoreWordsInUppercase;
 	CSpellCheckSettings.prototype['get_IgnoreWordsWithNumbers'] = CSpellCheckSettings.prototype.get_IgnoreWordsWithNumbers = CSpellCheckSettings.prototype.IsIgnoreWordsWithNumbers;
 	CSpellCheckSettings.prototype['put_IgnoreWordsWithNumbers'] = CSpellCheckSettings.prototype.put_IgnoreWordsWithNumbers = CSpellCheckSettings.prototype.SetIgnoreWordsWithNumbers;
+	CSpellCheckSettings.prototype['get_WavyLine'] = CSpellCheckSettings.prototype.get_WavyLine = CSpellCheckSettings.prototype.IsWavyLine;
+	CSpellCheckSettings.prototype['put_WavyLine'] = CSpellCheckSettings.prototype.put_WavyLine = CSpellCheckSettings.prototype.SetWavyLine;
 
 })(window);

--- a/word/Drawing/Graphics.js
+++ b/word/Drawing/Graphics.js
@@ -2141,18 +2141,11 @@
 	CGraphics.prototype.IsSpellCheckWavyLine = function()
 	{
 		let oLogicDocument = Asc.editor && Asc.editor.private_GetLogicDocument ? Asc.editor.private_GetLogicDocument() : null;
-		if (oLogicDocument && oLogicDocument.GetSpellCheckManager)
-		{
-			let oSpellCheck = oLogicDocument.GetSpellCheckManager();
-			return oSpellCheck ? oSpellCheck.GetSettings().IsWavyLine() : true;
-		}
+		if (!oLogicDocument || !oLogicDocument.GetSpellCheckManager)
+			return true;
 
-		// Editors without a SpellCheckManager-backed logic document (e.g. cell/api.js)
-		// may still expose settings directly, for shape text spellcheck rendering.
-		if (Asc.editor && Asc.editor.asc_getSpellCheckSettings)
-			return Asc.editor.asc_getSpellCheckSettings().IsWavyLine();
-
-		return true;
+		let oSpellCheck = oLogicDocument.GetSpellCheckManager();
+		return oSpellCheck ? oSpellCheck.GetSettings().IsWavyLine() : true;
 	};
 
 	CGraphics.prototype.DrawSpellingLine = function(y0, x0, x1, w)

--- a/word/Drawing/Graphics.js
+++ b/word/Drawing/Graphics.js
@@ -2138,20 +2138,35 @@
 			this.SetIntegerGrid(false);
 	};
 
+	CGraphics.prototype.IsSpellCheckWavyLine = function()
+	{
+		let oLogicDocument = Asc.editor && Asc.editor.private_GetLogicDocument ? Asc.editor.private_GetLogicDocument() : null;
+		if (!oLogicDocument || !oLogicDocument.GetSpellCheckManager)
+			return true;
+
+		let oSpellCheck = oLogicDocument.GetSpellCheckManager();
+		return oSpellCheck ? oSpellCheck.GetSettings().IsWavyLine() : true;
+	};
+
 	CGraphics.prototype.DrawSpellingLine = function(y0, x0, x1, w)
 	{
-		if (!Asc.editor.isViewMode)
+		if (Asc.editor.isViewMode)
+			return;
+
+		if (this.IsSpellCheckWavyLine())
+			this.drawWavyLine(y0, x0, x1, w);
+		else
 			this.drawHorLine(0, y0, x0, x1, w );
 	};
-	
+
 	CGraphics.prototype.drawCustomRange = function(handlerId, rangeId, x0, y0, w, h, baseLine)
 	{
 		if (Asc.editor.isViewMode)
 			return;
-		
+
 		let color = AscCommon.getUserColorById(handlerId, null, false);
 		let underlineY = 0.1 * (baseLine - y0) + baseLine;
-		
+
 		if (-1 !== handlerId.indexOf("spelling"))
 		{
 			color = new AscCommon.CColor(239, 68, 68, 255);
@@ -2161,10 +2176,54 @@
 			color = new AscCommon.CColor(59, 130, 246, 255);
 			underlineY = 0.2 * (baseLine - y0) + baseLine;
 		}
-		
+
 		this.p_color(color.r, color.g, color.b, 255);
 		this.p_width(0.25 * 1000);
-		this.drawHorLine(0, underlineY, x0, x0 + w, 0.25 );
+
+		if (-1 !== handlerId.indexOf("spelling") && this.IsSpellCheckWavyLine())
+			this.drawWavyLine(underlineY, x0, x0 + w, 0.25);
+		else
+			this.drawHorLine(0, underlineY, x0, x0 + w, 0.25 );
+	};
+
+	// Wavy underline used for misspelled-word markers (replaces the straight
+	// dashed line when CSpellCheckSettings.IsWavyLine() is true). Approximates
+	// a sinusoid with alternating-amplitude cubic bezier segments, matching the
+	// straight-line variant's coordinate/transform handling in drawHorLine.
+	CGraphics.prototype.drawWavyLine = function(y, x, r, penW)
+	{
+		var _check_transform = global_MatrixTransformer.IsIdentity2(this.m_oTransform);
+		if (!this.m_bIntegerGrid || !_check_transform)
+		{
+			if (_check_transform)
+			{
+				this.SetIntegerGrid(true);
+				this.drawWavyLine(y, x, r, penW);
+				this.SetIntegerGrid(false);
+				return;
+			}
+		}
+
+		this.p_width(penW * 1000);
+
+		var amplitude = 0.5;
+		var half_period = 1.5;
+		var segments = Math.max(1, Math.round((r - x) / half_period));
+		var dx = (r - x) / segments;
+
+		this._s();
+		this._m(x, y);
+		for (var i = 0; i < segments; i++)
+		{
+			var a = (i % 2 === 0) ? -amplitude : amplitude;
+			var cx1 = x + i * dx + dx / 3.0;
+			var cy1 = y + a;
+			var cx2 = x + i * dx + 2.0 * dx / 3.0;
+			var cy2 = y + a;
+			var px = x + (i + 1) * dx;
+			this._c(cx1, cy1, cx2, cy2, px, y);
+		}
+		this.ds();
 	};
 
 	// smart methods for horizontal / vertical lines

--- a/word/Drawing/Graphics.js
+++ b/word/Drawing/Graphics.js
@@ -2141,11 +2141,18 @@
 	CGraphics.prototype.IsSpellCheckWavyLine = function()
 	{
 		let oLogicDocument = Asc.editor && Asc.editor.private_GetLogicDocument ? Asc.editor.private_GetLogicDocument() : null;
-		if (!oLogicDocument || !oLogicDocument.GetSpellCheckManager)
-			return true;
+		if (oLogicDocument && oLogicDocument.GetSpellCheckManager)
+		{
+			let oSpellCheck = oLogicDocument.GetSpellCheckManager();
+			return oSpellCheck ? oSpellCheck.GetSettings().IsWavyLine() : true;
+		}
 
-		let oSpellCheck = oLogicDocument.GetSpellCheckManager();
-		return oSpellCheck ? oSpellCheck.GetSettings().IsWavyLine() : true;
+		// Editors without a SpellCheckManager-backed logic document (e.g. cell/api.js)
+		// may still expose settings directly, for shape text spellcheck rendering.
+		if (Asc.editor && Asc.editor.asc_getSpellCheckSettings)
+			return Asc.editor.asc_getSpellCheckSettings().IsWavyLine();
+
+		return true;
 	};
 
 	CGraphics.prototype.DrawSpellingLine = function(y0, x0, x1, w)

--- a/word/Editor/Paragraph.js
+++ b/word/Editor/Paragraph.js
@@ -3340,7 +3340,7 @@ Paragraph.prototype.drawRunContentLines = function(CurPage, pGraphics, drawState
 				if(drawingDocument)
 				{
 					pGraphics.p_color(255, 0, 0, 255);
-					let SpellingW = drawingDocument.GetMMPerDot(1);
+					let SpellingW = drawingDocument.GetMMPerDot(3);
 					Element       = aSpelling.Get_Next();
 					while (null != Element)
 					{


### PR DESCRIPTION
Adding the option of the original straight line or a wavy line to underline mispelled words: https://github.com/Euro-Office/DesktopEditors/issues/3