### PR TITLE
chore(lint): enable no-undef for the native browser shims

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+# Vendored jQuery fork. tests/code-style/check.py excludes it as well.
+common/Native/jquery_native.js

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -36,3 +36,49 @@ rules:
   # Stylistic Issues
   # http://eslint.org/docs/rules/#stylistic-issues
   linebreak-style: [error, unix]
+
+overrides:
+  # The files in common/Native stub the browser environment for the embedded JS
+  # context used by DoctRenderer/x2t. Nothing in CI executes that bundle - the
+  # QUnit suites run in a real browser, where these stubs are never loaded - so
+  # an undeclared identifier here reaches production completely unexercised.
+  # That is how console.error() came to reference an undeclared `param` and
+  # abort every converter operation that logged an error.
+  #
+  # no-undef is enabled for this directory only. Enabling it repo-wide would
+  # report ~86k violations across 1437 identifiers, almost all of them
+  # legitimate cross-module namespaces (AscCommon, AscDFH, Asc, AscFormat, ...),
+  # which would need a globals list larger than the rule is worth.
+  # `browser: false` in both blocks below is deliberate and load-bearing. These
+  # files *provide* window/document/navigator/console/setTimeout/performance for
+  # a context that has none. Treating them as browser code makes every stub read
+  # as a redeclaration of a built-in and buries the real defects in the noise.
+  #
+  # The two host globals are injected by the converter before any script runs:
+  #   window             -> the global object itself, doctrenderer.cpp:579
+  #   native             -> doctrenderer.cpp:583 (global_js->set("native", ...))
+  #   CreateEmbedObject  -> js_internal/v8/v8_base.cpp:218 (InsertToGlobal)
+  - files:
+      - common/Native/native.js
+    env:
+      browser: false
+      es2015: true
+    globals:
+      window: readonly
+      native: readonly
+    rules:
+      no-undef: error
+
+  - files:
+      - common/Native/native_graphics.js
+    env:
+      browser: false
+      es2015: true
+    globals:
+      window: readonly
+      CreateEmbedObject: readonly
+      # Declared by native.js, which editors.cpp (GetAllScript) concatenates
+      # ahead of this file.
+      AscCommon: readonly
+    rules:
+      no-undef: error

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -22,6 +22,18 @@ jobs:
       - name: execute check styles
         run: python tests/code-style/check.py
 
+      - name: setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      # Scoped to common/Native on purpose - see the overrides block in
+      # .eslintrc.yaml. Those shims are the one part of the tree that no test
+      # ever executes, so no-undef is the only thing standing between an
+      # undeclared identifier and a converter that aborts on every logged error.
+      - name: lint native shims
+        run: npx --yes eslint@8.57.1 'common/Native/*.js'
+
   unit-tests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Follow-up to Euro-Office/sdkjs#67. **Merge #67 first** — see "Expected CI state" below.

## Why

`common/Native/` stubs `window`, `document`, `navigator`, `console`, `setTimeout` and `performance` for the embedded JS context that DoctRenderer/x2t runs. It is the one part of this tree that **no test ever executes**: `tests/runAll.js` and the `unit-tests` job drive QUnit in a real browser via `node-qunit-puppeteer`, where these stubs are never loaded and the real platform objects are used instead.

So an undeclared identifier in these files reaches production entirely unexercised. That is exactly how `console.error` came to reference an undeclared `param` and abort every converter operation that logged an error — silent save failure, ExitCode 86, data loss. Five weeks of dormancy, then production.

`no-undef` catches it. `.eslintrc.yaml` did not enable it, and nothing ran eslint at all — there is no eslint reference in `build/package.json`, no root `package.json`, and the `code-style` job only ran `tests/code-style/check.py` (license headers, LF endings, trailing newline).

## Proof it's a real guard

Against `main` as it stands today:

```
$ eslint --format unix 'common/Native/*.js'
common/Native/native.js:340:78: 'param' is not defined. [Error/no-undef]

1 problem
```

With #67's one-word fix applied: clean, exit 0. One error, the right error, no noise.

## Why it's scoped to common/Native

Repo-wide, `no-undef` reports **85,854 violations across 1,437 distinct identifiers**, measured per directory (common 26,446 / word 27,779 / cell 15,658 / slide 7,574 / pdf 6,543 / visio 1,854). The top offenders are legitimate cross-module namespaces:

| identifier | count |
|---|---|
| `AscCommon` | 16,525 |
| `AscDFH` | 16,021 |
| `Asc` | 13,402 |
| `AscFormat` | 12,797 |
| `AscCommonExcel` | 4,712 |

Making that green would need a globals list larger than the rule is worth, so this PR does not attempt it. Widening the scope later is a separate conversation with a separate cost.

## Why `browser: false`

Counter-intuitive but load-bearing. These files *provide* the browser globals rather than consuming them. With `browser: true` the existing `no-redeclare` rule fires on every stub — `navigator`, `document`, `console`, `setTimeout`, `setInterval`, `clearTimeout`, `clearInterval`, `performance`, `Image` — and buries the one real defect in eleven false ones. I hit exactly that while building this; the first draft reported 12 problems, of which 11 were noise.

With `browser: false`, the three globals the converter genuinely injects before any script runs are declared explicitly, each pointing at where `core` installs it:

| global | installed by |
|---|---|
| `window` (the global object itself) | `doctrenderer.cpp:579` — `global_js->set("window", global_js)` |
| `native` | `doctrenderer.cpp:583` — `global_js->set("native", oNativeCtrl)` |
| `CreateEmbedObject` | `js_internal/v8/v8_base.cpp:218` — `InsertToGlobal(...)` |

Split into two per-file override blocks because `native.js` declares `Asc`/`AscCommon`/`AscFormat`/`AscDFH` itself, whereas `native_graphics.js` consumes `AscCommon` from it — `editors.cpp` (`GetAllScript`) concatenates them in that order. Declaring `AscCommon` globally for both would trip `no-redeclare` on `native.js`'s own `var AscCommon = {}`.

`jquery_native.js` is ignored via `.eslintignore`, matching `tests/code-style/check.py`'s own `exclude_files`.

## Expected CI state

**`code-style` will fail on this branch until #67 merges**, with exactly:

```
common/Native/native.js:340:78: 'param' is not defined. [Error/no-undef]
```

That failure is the demonstration, not a defect in this PR. Merge #67, and this goes green with no changes.

## Divergence cost

`.eslintrc.yaml` and `.github/workflows/check-build.yml` both exist upstream, so this is real fork divergence. It is confined to an `overrides:` block appended to the end of one file and one step added to one job — upstream touches neither often — and `.eslintignore` is a new file, so it cannot conflict. Judged worth it: the alternative is relying on nobody ever again writing an undeclared identifier in the only directory CI cannot reach.
