### PR TITLE
fix: Use correct quotation marks for Danish

### DIFF
--- a/word/Editor/Paragraph/Run/RunAutoCorrect.js
+++ b/word/Editor/Paragraph/Run/RunAutoCorrect.js
@@ -382,7 +382,7 @@
 		return true;
 	};
 	/**
-	 * Производим автозамену для умных кавычек
+	 * Perform auto-replacement for typographer's quotation marks (Smart quotes)
 	 * @returns {boolean}
 	 */
 	CRunAutoCorrect.prototype.private_ProcessSmartQuotesAutoCorrect = function()
@@ -465,7 +465,6 @@
 					this.Run.AddToContent(this.Pos, new AscWord.CRunText(isOpenQuote ? 0x201E : 0x201D));
 					break;
 				}
-				case 1030:
 				case 1035:
 				case 1053:
 				{
@@ -479,6 +478,7 @@
 					this.Run.AddToContent(this.Pos, new AscWord.CRunText(isOpenQuote ? 0x00AB : 0x00BB));
 					break;
 				}
+				case 1030:
 				case 1060:
 				{
 					// »text«


### PR DESCRIPTION
Danish typographic tradition uses two standards for quotation marks.

1. Guillemets pointing to the quote: »Example«.
2. Down-9s and Up-6s: „Example“.

Eurooffice currently has dual Up-9s set for Danish: ”Example”.

This commit changes Danish typographer's quotes or smart quotes to guillemets, which is the most widespread in professional Danish typography. 

I have intentionally left the single quotes as they are, since using the correct ones tends to cause issues with apostrophes.