### PR TITLE
fix(pdf): prevent PDF annotation date corruption on save

### DIFF
--- a/pdf/src/annotations/base.js
+++ b/pdf/src/annotations/base.js
@@ -1773,7 +1773,8 @@
         // modification date
         if (Flags & (1 << 5)) {
             let sModDate = memory.GetString();
-            this.SetModDate(sModDate);
+            let oModDate = ParsePDFDate(sModDate);
+            this.SetModDate(oModDate ? oModDate.getTime().toString() : sModDate);
         }
     
         // user ID
@@ -1945,7 +1946,8 @@
             let CrDate = null;
             if (memory.annotFlags & (1 << 4)) {
                 CrDate = memory.GetString();
-                this.SetCreationDate(CrDate);
+                let oCrDate = ParsePDFDate(CrDate);
+                this.SetCreationDate(oCrDate ? oCrDate.getTime().toString() : CrDate);
             }
     
             let oRefTo = null;

--- a/pdf/src/annotations/base.js
+++ b/pdf/src/annotations/base.js
@@ -2000,7 +2000,7 @@
 
     function ParsePDFDate(sDate) {
         // Регулярное выражение для извлечения компонентов даты
-        let regex = /D:(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})([Z\+\-]?)(\d{2})?'?(\d{2})?/;
+        let regex = /D:(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})([Z\+\-=]?)(\d{2})?'?(\d{2})?/;
 
         // Используем регулярное выражение для извлечения компонентов даты
         let match = sDate.match(regex);
@@ -2021,8 +2021,8 @@
             let date = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
 
             // Учитываем смещение времени
-            if (timeZoneSign === 'Z') {
-                // Если указано "Z", это означает UTC
+            if (timeZoneSign === 'Z' || timeZoneSign === '=' || !timeZoneSign) {
+                // Если указано "Z" или "=", это означает UTC
             } else if (timeZoneSign === '+') {
                 date.setHours(date.getHours() - timeZoneOffsetHours);
                 date.setMinutes(date.getMinutes() - timeZoneOffsetMinutes);
@@ -2071,15 +2071,12 @@
         // Calculate timezone offset
         let timezoneOffsetMinutes = date.getTimezoneOffset();
         
-        let timezoneOffsetSign;
-        if (timezoneOffsetMinutes < 0)
-            timezoneOffsetSign = '+';
-        else if (timezoneOffsetMinutes > 0)
-            timezoneOffsetSign = '-';
-        else if (timezoneOffsetMinutes == 0)
-            timezoneOffsetSign = '=';
+        if (timezoneOffsetMinutes === 0)
+            return 'D:' + year + month + day + hours + minutes + seconds + 'Z';
 
-        
+        let timezoneOffsetSign = timezoneOffsetMinutes < 0 ? '+' : '-';
+
+
         let timezoneOffsetHours = Math.abs(Math.floor(timezoneOffsetMinutes / 60)) >> 0;
         if (timezoneOffsetHours < 10)
             timezoneOffsetHours = '0' + timezoneOffsetHours.toString();

--- a/pdf/src/history/annotsChanges.js
+++ b/pdf/src/history/annotsChanges.js
@@ -1110,13 +1110,13 @@ CChangesPDFAnnotContents.prototype.private_SetValue = function(Value)
 
 /**
  * @constructor
- * @extends {AscDFH.CChangesBaseLongProperty}
+ * @extends {AscDFH.CChangesBaseStringProperty}
  */
 function CChangesPDFAnnotCreationDate(Class, Old, New, Color)
 {
-	AscDFH.CChangesBaseLongProperty.call(this, Class, Old, New, Color);
+	AscDFH.CChangesBaseStringProperty.call(this, Class, Old, New, Color);
 }
-CChangesPDFAnnotCreationDate.prototype = Object.create(AscDFH.CChangesBaseLongProperty.prototype);
+CChangesPDFAnnotCreationDate.prototype = Object.create(AscDFH.CChangesBaseStringProperty.prototype);
 CChangesPDFAnnotCreationDate.prototype.constructor = CChangesPDFAnnotCreationDate;
 CChangesPDFAnnotCreationDate.prototype.Type = AscDFH.historyitem_Pdf_Annot_Creation_Date;
 CChangesPDFAnnotCreationDate.prototype.private_SetValue = function(Value)
@@ -1127,13 +1127,13 @@ CChangesPDFAnnotCreationDate.prototype.private_SetValue = function(Value)
 
 /**
  * @constructor
- * @extends {AscDFH.CChangesBaseLongProperty}
+ * @extends {AscDFH.CChangesBaseStringProperty}
  */
 function CChangesPDFAnnotModDate(Class, Old, New, Color)
 {
-	AscDFH.CChangesBaseLongProperty.call(this, Class, Old, New, Color);
+	AscDFH.CChangesBaseStringProperty.call(this, Class, Old, New, Color);
 }
-CChangesPDFAnnotModDate.prototype = Object.create(AscDFH.CChangesBaseLongProperty.prototype);
+CChangesPDFAnnotModDate.prototype = Object.create(AscDFH.CChangesBaseStringProperty.prototype);
 CChangesPDFAnnotModDate.prototype.constructor = CChangesPDFAnnotModDate;
 CChangesPDFAnnotModDate.prototype.Type = AscDFH.historyitem_Pdf_Annot_Mod_Date;
 CChangesPDFAnnotModDate.prototype.private_SetValue = function(Value)


### PR DESCRIPTION
- Fix: PDF comment/annotation dates showed as 1/20/70 or similar after a save+reload.
Root cause: CChangesPDFAnnotCreationDate/ModDate stored the ms-epoch timestamp via a 32-bit WriteLong, silently truncating it (value mod 2^32) every time it round-tripped through the collaborative changes journal.

- Fix: formatTimestampToPDF writing an invalid = timezone marker for UTC (PDF spec only allows Z/+/-); now emits Z.

 Fixes Euro-Office/DocumentServer#357